### PR TITLE
Change join queue request for only one queue

### DIFF
--- a/docs/schema/matchmaking.md
+++ b/docs/schema/matchmaking.md
@@ -5,7 +5,7 @@
 The matchmaking cycle works as follows:
 
 1. Clients should first retrieve a list of all the available queues from the server using [list](#list).
-2. Clients should then queue for one or more of these queues by sending an array of the queue ids in a [queue](#queue) request.
+2. Clients should then queue for one or more of these queues by sending the queue id in several [queue](#queue) requests.
 3. The server can send periodic updates about the status of the search as a [queueUpdate](#queueupdate) event.
 4. When a match is found, the server should send a [found](#found) event along with the id of the queue of the found match.
 5. Clients can then ready up by sending a [ready](#ready) request. The number of readied players should be sent to clients via the [readyUpdate](#readyupdate) event.
@@ -13,6 +13,7 @@ The matchmaking cycle works as follows:
 7. If a client fails to ready up for a found match, the server should send a [lost](#lost) event, and the queueing phase should resume.
 8. Once all players are ready, the server should send a [autohost/battleStart](#autohost/battleStart) request to a suitable autohost client. If the autohost doesn't respond quickly, or if it sends a failed response, the server should repeat this step.
 9. Once the autohost has successfully started the battle, the server should then send [battle/battleStart](#battle/battleStart) requests to the users.
+
 ---
 - [cancel](#cancel)
 - [found](#found)
@@ -564,7 +565,7 @@ export interface MatchmakingLostEvent {
 
 ## Queue
 
-Queue up for matchmaking. Should cancel the previous queue if already in one.
+Queue up for matchmaking on the specific queue id.
 
 - Endpoint Type: **Event**
 - Source: **User**
@@ -592,14 +593,8 @@ Queue up for matchmaking. Should cancel the previous queue if already in one.
         "data": {
             "title": "MatchmakingQueueRequestData",
             "type": "object",
-            "properties": {
-                "queues": {
-                    "type": "array",
-                    "items": { "type": "string" },
-                    "minItems": 1
-                }
-            },
-            "required": ["queues"]
+            "properties": { "queue": { "type": "string" } },
+            "required": ["queue"]
         }
     },
     "required": ["type", "messageId", "commandId", "data"]
@@ -617,10 +612,7 @@ Queue up for matchmaking. Should cancel the previous queue if already in one.
     "messageId": "nisi deserunt",
     "commandId": "matchmaking/queue",
     "data": {
-        "queues": [
-            "nisi deserunt",
-            "nisi deserunt"
-        ]
+        "queue": "nisi deserunt"
     }
 }
 ```
@@ -635,7 +627,7 @@ export interface MatchmakingQueueRequest {
     data: MatchmakingQueueRequestData;
 }
 export interface MatchmakingQueueRequestData {
-    queues: [string, ...string[]];
+    queue: string;
 }
 ```
 ### Response

--- a/schema/compiled.json
+++ b/schema/compiled.json
@@ -1521,14 +1521,8 @@
                 "data": {
                     "title": "MatchmakingQueueRequestData",
                     "type": "object",
-                    "properties": {
-                        "queues": {
-                            "type": "array",
-                            "items": { "type": "string" },
-                            "minItems": 1
-                        }
-                    },
-                    "required": ["queues"]
+                    "properties": { "queue": { "type": "string" } },
+                    "required": ["queue"]
                 }
             },
             "required": ["type", "messageId", "commandId", "data"]

--- a/schema/matchmaking/queue/request.json
+++ b/schema/matchmaking/queue/request.json
@@ -15,14 +15,8 @@
         "data": {
             "title": "MatchmakingQueueRequestData",
             "type": "object",
-            "properties": {
-                "queues": {
-                    "type": "array",
-                    "items": { "type": "string" },
-                    "minItems": 1
-                }
-            },
-            "required": ["queues"]
+            "properties": { "queue": { "type": "string" } },
+            "required": ["queue"]
         }
     },
     "required": ["type", "messageId", "commandId", "data"]

--- a/src/schema/matchmaking/README.md
+++ b/src/schema/matchmaking/README.md
@@ -1,7 +1,7 @@
 The matchmaking cycle works as follows:
 
 1. Clients should first retrieve a list of all the available queues from the server using [list](#list).
-2. Clients should then queue for one or more of these queues by sending an array of the queue ids in a [queue](#queue) request.
+2. Clients should then queue for one or more of these queues by sending the queue id in several [queue](#queue) requests.
 3. The server can send periodic updates about the status of the search as a [queueUpdate](#queueupdate) event.
 4. When a match is found, the server should send a [found](#found) event along with the id of the queue of the found match.
 5. Clients can then ready up by sending a [ready](#ready) request. The number of readied players should be sent to clients via the [readyUpdate](#readyupdate) event.

--- a/src/schema/matchmaking/queue.ts
+++ b/src/schema/matchmaking/queue.ts
@@ -5,10 +5,10 @@ import { defineEndpoint } from "@/generator-helpers.js";
 export default defineEndpoint({
     source: "user",
     target: "server",
-    description: "Queue up for matchmaking. Should cancel the previous queue if already in one.",
+    description: "Queue up for matchmaking on the specific queue id.",
     request: {
         data: Type.Object({
-            queues: Type.Array(Type.String(), { minItems: 1 }),
+            queue: Type.String(),
         }),
     },
     response: [

--- a/test/cjs/validator.test.cts
+++ b/test/cjs/validator.test.cts
@@ -15,7 +15,7 @@ describe("request", () => {
             commandId: "matchmaking/queue",
             messageId: "123",
             data: {
-                queues: ["1v1"],
+                queue: "1v1",
             },
         };
 
@@ -24,7 +24,7 @@ describe("request", () => {
         assert.equal(isValid, true);
 
         if (isValid) {
-            assert.equal(command.data.queues[0], "1v1");
+            assert.equal(command.data.queue, "1v1");
         }
     });
 
@@ -35,7 +35,7 @@ describe("request", () => {
             messageId: "123",
             data: {
                 // @ts-expect-error
-                queues: [],
+                queue: 123,
             },
         };
 

--- a/test/esm/validator.test.mts
+++ b/test/esm/validator.test.mts
@@ -15,7 +15,7 @@ describe("request", () => {
             commandId: "matchmaking/queue",
             messageId: "123",
             data: {
-                queues: ["1v1"],
+                queue: "1v1",
             },
         };
 
@@ -24,7 +24,7 @@ describe("request", () => {
         assert.equal(isValid, true);
 
         if (isValid) {
-            assert.equal(command.data.queues[0], "1v1");
+            assert.equal(command.data.queue, "1v1");
         }
     });
 


### PR DESCRIPTION
If a client wants to join many queues it can send multiple requests. This make the response and its semantics a lot simpler.