### PR TITLE
Specify queues

### DIFF
--- a/docs/schema/matchmaking.md
+++ b/docs/schema/matchmaking.md
@@ -52,9 +52,15 @@ Cancel queueing for matchmaking.
     "properties": {
         "type": { "const": "request" },
         "messageId": { "type": "string" },
-        "commandId": { "const": "matchmaking/cancel" }
+        "commandId": { "const": "matchmaking/cancel" },
+        "data": {
+            "title": "MatchmakingCancelRequestData",
+            "type": "object",
+            "properties": { "queueId": { "type": "string" } },
+            "required": ["queueId"]
+        }
     },
-    "required": ["type", "messageId", "commandId"]
+    "required": ["type", "messageId", "commandId", "data"]
 }
 
 ```
@@ -67,7 +73,10 @@ Cancel queueing for matchmaking.
 {
     "type": "request",
     "messageId": "magna commodo",
-    "commandId": "matchmaking/cancel"
+    "commandId": "matchmaking/cancel",
+    "data": {
+        "queueId": "magna commodo"
+    }
 }
 ```
 </details>
@@ -78,6 +87,10 @@ export interface MatchmakingCancelRequest {
     type: "request";
     messageId: string;
     commandId: "matchmaking/cancel";
+    data: MatchmakingCancelRequestData;
+}
+export interface MatchmakingCancelRequestData {
+    queueId: string;
 }
 ```
 ### Response
@@ -262,8 +275,11 @@ Server should send this when players ready up using [ready](#ready).
         "data": {
             "title": "MatchmakingFoundUpdateEventData",
             "type": "object",
-            "properties": { "readyCount": { "type": "integer" } },
-            "required": ["readyCount"]
+            "properties": {
+                "queueId": { "type": "string" },
+                "readyCount": { "type": "integer" }
+            },
+            "required": ["queueId", "readyCount"]
         }
     },
     "required": ["type", "messageId", "commandId", "data"]
@@ -281,6 +297,7 @@ Server should send this when players ready up using [ready](#ready).
     "messageId": "in exercitation",
     "commandId": "matchmaking/foundUpdate",
     "data": {
+        "queueId": "in exercitation",
         "readyCount": -48000000
     }
 }
@@ -296,6 +313,7 @@ export interface MatchmakingFoundUpdateEvent {
     data: MatchmakingFoundUpdateEventData;
 }
 export interface MatchmakingFoundUpdateEventData {
+    queueId: string;
     readyCount: number;
 }
 ```
@@ -510,6 +528,7 @@ Possible Failed Reasons: `internal_error`, `unauthorized`, `invalid_request`, `c
 ## Lost
 
 Sent when a found match gets disbanded because a client failed to ready up.
+      The player is put back into the queue when this happen.
 
 - Endpoint Type: **Event**
 - Source: **Server**
@@ -533,9 +552,15 @@ Sent when a found match gets disbanded because a client failed to ready up.
     "properties": {
         "type": { "const": "event" },
         "messageId": { "type": "string" },
-        "commandId": { "const": "matchmaking/lost" }
+        "commandId": { "const": "matchmaking/lost" },
+        "data": {
+            "title": "MatchmakingLostEventData",
+            "type": "object",
+            "properties": { "queueId": { "type": "string" } },
+            "required": ["queueId"]
+        }
     },
-    "required": ["type", "messageId", "commandId"]
+    "required": ["type", "messageId", "commandId", "data"]
 }
 
 ```
@@ -548,7 +573,10 @@ Sent when a found match gets disbanded because a client failed to ready up.
 {
     "type": "event",
     "messageId": "commodo laborum",
-    "commandId": "matchmaking/lost"
+    "commandId": "matchmaking/lost",
+    "data": {
+        "queueId": "commodo laborum"
+    }
 }
 ```
 </details>
@@ -559,6 +587,10 @@ export interface MatchmakingLostEvent {
     type: "event";
     messageId: string;
     commandId: "matchmaking/lost";
+    data: MatchmakingLostEventData;
+}
+export interface MatchmakingLostEventData {
+    queueId: string;
 }
 ```
 ---
@@ -740,8 +772,11 @@ Contains some info about the state of the current queue.
         "data": {
             "title": "MatchmakingQueueUpdateEventData",
             "type": "object",
-            "properties": { "playersQueued": { "type": "string" } },
-            "required": ["playersQueued"]
+            "properties": {
+                "queueId": { "type": "string" },
+                "playersQueued": { "type": "string" }
+            },
+            "required": ["queueId", "playersQueued"]
         }
     },
     "required": ["type", "messageId", "commandId", "data"]
@@ -759,6 +794,7 @@ Contains some info about the state of the current queue.
     "messageId": "laboris non",
     "commandId": "matchmaking/queueUpdate",
     "data": {
+        "queueId": "laboris non",
         "playersQueued": "laboris non"
     }
 }
@@ -774,6 +810,7 @@ export interface MatchmakingQueueUpdateEvent {
     data: MatchmakingQueueUpdateEventData;
 }
 export interface MatchmakingQueueUpdateEventData {
+    queueId: string;
     playersQueued: string;
 }
 ```
@@ -805,9 +842,15 @@ Clients should send this when they are ready to proceed with the found match. If
     "properties": {
         "type": { "const": "request" },
         "messageId": { "type": "string" },
-        "commandId": { "const": "matchmaking/ready" }
+        "commandId": { "const": "matchmaking/ready" },
+        "data": {
+            "title": "MatchmakingReadyRequestData",
+            "type": "object",
+            "properties": { "queueId": { "type": "string" } },
+            "required": ["queueId"]
+        }
     },
-    "required": ["type", "messageId", "commandId"]
+    "required": ["type", "messageId", "commandId", "data"]
 }
 
 ```
@@ -820,7 +863,10 @@ Clients should send this when they are ready to proceed with the found match. If
 {
     "type": "request",
     "messageId": "ullamco occaecat",
-    "commandId": "matchmaking/ready"
+    "commandId": "matchmaking/ready",
+    "data": {
+        "queueId": "ullamco occaecat"
+    }
 }
 ```
 </details>
@@ -831,6 +877,10 @@ export interface MatchmakingReadyRequest {
     type: "request";
     messageId: string;
     commandId: "matchmaking/ready";
+    data: MatchmakingReadyRequestData;
+}
+export interface MatchmakingReadyRequestData {
+    queueId: string;
 }
 ```
 ### Response
@@ -869,6 +919,7 @@ export interface MatchmakingReadyRequest {
                 "reason": {
                     "enum": [
                         "no_match",
+                        "invalid_queue_specified",
                         "internal_error",
                         "unauthorized",
                         "invalid_request",
@@ -907,7 +958,7 @@ export interface MatchmakingReadyOkResponse {
     status: "success";
 }
 ```
-Possible Failed Reasons: `no_match`, `internal_error`, `unauthorized`, `invalid_request`, `command_unimplemented`
+Possible Failed Reasons: `no_match`, `invalid_queue_specified`, `internal_error`, `unauthorized`, `invalid_request`, `command_unimplemented`
 
 ---
 
@@ -942,10 +993,11 @@ Sent when a client in a found match readies up.
             "title": "MatchmakingReadyUpdateEventData",
             "type": "object",
             "properties": {
+                "queueId": { "type": "integer" },
                 "readyMax": { "type": "integer" },
                 "readyCurrent": { "type": "integer" }
             },
-            "required": ["readyMax", "readyCurrent"]
+            "required": ["queueId", "readyMax", "readyCurrent"]
         }
     },
     "required": ["type", "messageId", "commandId", "data"]
@@ -963,6 +1015,7 @@ Sent when a client in a found match readies up.
     "messageId": "dolor Lorem",
     "commandId": "matchmaking/readyUpdate",
     "data": {
+        "queueId": -30000000,
         "readyMax": -30000000,
         "readyCurrent": -30000000
     }
@@ -979,6 +1032,7 @@ export interface MatchmakingReadyUpdateEvent {
     data: MatchmakingReadyUpdateEventData;
 }
 export interface MatchmakingReadyUpdateEventData {
+    queueId: number;
     readyMax: number;
     readyCurrent: number;
 }

--- a/docs/schema/matchmaking.md
+++ b/docs/schema/matchmaking.md
@@ -593,8 +593,8 @@ Queue up for matchmaking on the specific queue id.
         "data": {
             "title": "MatchmakingQueueRequestData",
             "type": "object",
-            "properties": { "queue": { "type": "string" } },
-            "required": ["queue"]
+            "properties": { "queueId": { "type": "string" } },
+            "required": ["queueId"]
         }
     },
     "required": ["type", "messageId", "commandId", "data"]
@@ -612,7 +612,7 @@ Queue up for matchmaking on the specific queue id.
     "messageId": "nisi deserunt",
     "commandId": "matchmaking/queue",
     "data": {
-        "queue": "nisi deserunt"
+        "queueId": "nisi deserunt"
     }
 }
 ```
@@ -627,7 +627,7 @@ export interface MatchmakingQueueRequest {
     data: MatchmakingQueueRequestData;
 }
 export interface MatchmakingQueueRequestData {
-    queue: string;
+    queueId: string;
 }
 ```
 ### Response

--- a/schema/compiled.json
+++ b/schema/compiled.json
@@ -1279,9 +1279,15 @@
             "properties": {
                 "type": { "const": "request" },
                 "messageId": { "type": "string" },
-                "commandId": { "const": "matchmaking/cancel" }
+                "commandId": { "const": "matchmaking/cancel" },
+                "data": {
+                    "title": "MatchmakingCancelRequestData",
+                    "type": "object",
+                    "properties": { "queueId": { "type": "string" } },
+                    "required": ["queueId"]
+                }
             },
-            "required": ["type", "messageId", "commandId"]
+            "required": ["type", "messageId", "commandId", "data"]
         },
         {
             "title": "MatchmakingCancelResponse",
@@ -1370,8 +1376,11 @@
                 "data": {
                     "title": "MatchmakingFoundUpdateEventData",
                     "type": "object",
-                    "properties": { "readyCount": { "type": "integer" } },
-                    "required": ["readyCount"]
+                    "properties": {
+                        "queueId": { "type": "string" },
+                        "readyCount": { "type": "integer" }
+                    },
+                    "required": ["queueId", "readyCount"]
                 }
             },
             "required": ["type", "messageId", "commandId", "data"]
@@ -1502,9 +1511,15 @@
             "properties": {
                 "type": { "const": "event" },
                 "messageId": { "type": "string" },
-                "commandId": { "const": "matchmaking/lost" }
+                "commandId": { "const": "matchmaking/lost" },
+                "data": {
+                    "title": "MatchmakingLostEventData",
+                    "type": "object",
+                    "properties": { "queueId": { "type": "string" } },
+                    "required": ["queueId"]
+                }
             },
-            "required": ["type", "messageId", "commandId"]
+            "required": ["type", "messageId", "commandId", "data"]
         },
         {
             "title": "MatchmakingQueueRequest",
@@ -1592,8 +1607,11 @@
                 "data": {
                     "title": "MatchmakingQueueUpdateEventData",
                     "type": "object",
-                    "properties": { "playersQueued": { "type": "string" } },
-                    "required": ["playersQueued"]
+                    "properties": {
+                        "queueId": { "type": "string" },
+                        "playersQueued": { "type": "string" }
+                    },
+                    "required": ["queueId", "playersQueued"]
                 }
             },
             "required": ["type", "messageId", "commandId", "data"]
@@ -1609,9 +1627,15 @@
             "properties": {
                 "type": { "const": "request" },
                 "messageId": { "type": "string" },
-                "commandId": { "const": "matchmaking/ready" }
+                "commandId": { "const": "matchmaking/ready" },
+                "data": {
+                    "title": "MatchmakingReadyRequestData",
+                    "type": "object",
+                    "properties": { "queueId": { "type": "string" } },
+                    "required": ["queueId"]
+                }
             },
-            "required": ["type", "messageId", "commandId"]
+            "required": ["type", "messageId", "commandId", "data"]
         },
         {
             "title": "MatchmakingReadyResponse",
@@ -1643,6 +1667,7 @@
                         "reason": {
                             "enum": [
                                 "no_match",
+                                "invalid_queue_specified",
                                 "internal_error",
                                 "unauthorized",
                                 "invalid_request",
@@ -1677,10 +1702,11 @@
                     "title": "MatchmakingReadyUpdateEventData",
                     "type": "object",
                     "properties": {
+                        "queueId": { "type": "integer" },
                         "readyMax": { "type": "integer" },
                         "readyCurrent": { "type": "integer" }
                     },
-                    "required": ["readyMax", "readyCurrent"]
+                    "required": ["queueId", "readyMax", "readyCurrent"]
                 }
             },
             "required": ["type", "messageId", "commandId", "data"]

--- a/schema/compiled.json
+++ b/schema/compiled.json
@@ -1521,8 +1521,8 @@
                 "data": {
                     "title": "MatchmakingQueueRequestData",
                     "type": "object",
-                    "properties": { "queue": { "type": "string" } },
-                    "required": ["queue"]
+                    "properties": { "queueId": { "type": "string" } },
+                    "required": ["queueId"]
                 }
             },
             "required": ["type", "messageId", "commandId", "data"]

--- a/schema/matchmaking/cancel/request.json
+++ b/schema/matchmaking/cancel/request.json
@@ -11,7 +11,13 @@
     "properties": {
         "type": { "const": "request" },
         "messageId": { "type": "string" },
-        "commandId": { "const": "matchmaking/cancel" }
+        "commandId": { "const": "matchmaking/cancel" },
+        "data": {
+            "title": "MatchmakingCancelRequestData",
+            "type": "object",
+            "properties": { "queueId": { "type": "string" } },
+            "required": ["queueId"]
+        }
     },
-    "required": ["type", "messageId", "commandId"]
+    "required": ["type", "messageId", "commandId", "data"]
 }

--- a/schema/matchmaking/foundUpdate/event.json
+++ b/schema/matchmaking/foundUpdate/event.json
@@ -15,8 +15,11 @@
         "data": {
             "title": "MatchmakingFoundUpdateEventData",
             "type": "object",
-            "properties": { "readyCount": { "type": "integer" } },
-            "required": ["readyCount"]
+            "properties": {
+                "queueId": { "type": "string" },
+                "readyCount": { "type": "integer" }
+            },
+            "required": ["queueId", "readyCount"]
         }
     },
     "required": ["type", "messageId", "commandId", "data"]

--- a/schema/matchmaking/lost/event.json
+++ b/schema/matchmaking/lost/event.json
@@ -11,7 +11,13 @@
     "properties": {
         "type": { "const": "event" },
         "messageId": { "type": "string" },
-        "commandId": { "const": "matchmaking/lost" }
+        "commandId": { "const": "matchmaking/lost" },
+        "data": {
+            "title": "MatchmakingLostEventData",
+            "type": "object",
+            "properties": { "queueId": { "type": "string" } },
+            "required": ["queueId"]
+        }
     },
-    "required": ["type", "messageId", "commandId"]
+    "required": ["type", "messageId", "commandId", "data"]
 }

--- a/schema/matchmaking/queue/request.json
+++ b/schema/matchmaking/queue/request.json
@@ -15,8 +15,8 @@
         "data": {
             "title": "MatchmakingQueueRequestData",
             "type": "object",
-            "properties": { "queue": { "type": "string" } },
-            "required": ["queue"]
+            "properties": { "queueId": { "type": "string" } },
+            "required": ["queueId"]
         }
     },
     "required": ["type", "messageId", "commandId", "data"]

--- a/schema/matchmaking/queueUpdate/event.json
+++ b/schema/matchmaking/queueUpdate/event.json
@@ -15,8 +15,11 @@
         "data": {
             "title": "MatchmakingQueueUpdateEventData",
             "type": "object",
-            "properties": { "playersQueued": { "type": "string" } },
-            "required": ["playersQueued"]
+            "properties": {
+                "queueId": { "type": "string" },
+                "playersQueued": { "type": "string" }
+            },
+            "required": ["queueId", "playersQueued"]
         }
     },
     "required": ["type", "messageId", "commandId", "data"]

--- a/schema/matchmaking/ready/request.json
+++ b/schema/matchmaking/ready/request.json
@@ -11,7 +11,13 @@
     "properties": {
         "type": { "const": "request" },
         "messageId": { "type": "string" },
-        "commandId": { "const": "matchmaking/ready" }
+        "commandId": { "const": "matchmaking/ready" },
+        "data": {
+            "title": "MatchmakingReadyRequestData",
+            "type": "object",
+            "properties": { "queueId": { "type": "string" } },
+            "required": ["queueId"]
+        }
     },
-    "required": ["type", "messageId", "commandId"]
+    "required": ["type", "messageId", "commandId", "data"]
 }

--- a/schema/matchmaking/ready/response.json
+++ b/schema/matchmaking/ready/response.json
@@ -30,6 +30,7 @@
                 "reason": {
                     "enum": [
                         "no_match",
+                        "invalid_queue_specified",
                         "internal_error",
                         "unauthorized",
                         "invalid_request",

--- a/schema/matchmaking/readyUpdate/event.json
+++ b/schema/matchmaking/readyUpdate/event.json
@@ -16,10 +16,11 @@
             "title": "MatchmakingReadyUpdateEventData",
             "type": "object",
             "properties": {
+                "queueId": { "type": "integer" },
                 "readyMax": { "type": "integer" },
                 "readyCurrent": { "type": "integer" }
             },
-            "required": ["readyMax", "readyCurrent"]
+            "required": ["queueId", "readyMax", "readyCurrent"]
         }
     },
     "required": ["type", "messageId", "commandId", "data"]

--- a/src/schema/matchmaking/cancel.ts
+++ b/src/schema/matchmaking/cancel.ts
@@ -1,9 +1,15 @@
+import { Type } from "@sinclair/typebox";
+
 import { defineEndpoint } from "@/generator-helpers.js";
 
 export default defineEndpoint({
     source: "user",
     target: "server",
     description: "Cancel queueing for matchmaking.",
-    request: {},
+    request: {
+        data: Type.Object({
+            queueId: Type.String(),
+        }),
+    },
     response: [{ status: "success" }, { status: "failed", reason: "not_queued" }],
 });

--- a/src/schema/matchmaking/foundUpdate.ts
+++ b/src/schema/matchmaking/foundUpdate.ts
@@ -8,6 +8,7 @@ export default defineEndpoint({
     description: "Server should send this when players ready up using [ready](#ready).",
     event: {
         data: Type.Object({
+            queueId: Type.String(),
             readyCount: Type.Integer(),
         }),
     },

--- a/src/schema/matchmaking/lost.ts
+++ b/src/schema/matchmaking/lost.ts
@@ -1,8 +1,15 @@
+import { Type } from "@sinclair/typebox";
+
 import { defineEndpoint } from "@/generator-helpers.js";
 
 export default defineEndpoint({
     source: "server",
     target: "user",
-    description: "Sent when a found match gets disbanded because a client failed to ready up.",
-    event: {},
+    description: `Sent when a found match gets disbanded because a client failed to ready up.
+      The player is put back into the queue when this happen.`,
+    event: {
+        data: Type.Object({
+            queueId: Type.String(),
+        }),
+    },
 });

--- a/src/schema/matchmaking/queue.ts
+++ b/src/schema/matchmaking/queue.ts
@@ -8,7 +8,7 @@ export default defineEndpoint({
     description: "Queue up for matchmaking on the specific queue id.",
     request: {
         data: Type.Object({
-            queue: Type.String(),
+            queueId: Type.String(),
         }),
     },
     response: [

--- a/src/schema/matchmaking/queueUpdate.ts
+++ b/src/schema/matchmaking/queueUpdate.ts
@@ -8,6 +8,7 @@ export default defineEndpoint({
     description: "Contains some info about the state of the current queue.",
     event: {
         data: Type.Object({
+            queueId: Type.String(),
             playersQueued: Type.String(),
         }),
     },

--- a/src/schema/matchmaking/ready.ts
+++ b/src/schema/matchmaking/ready.ts
@@ -1,3 +1,5 @@
+import { Type } from "@sinclair/typebox";
+
 import { defineEndpoint } from "@/generator-helpers.js";
 
 export default defineEndpoint({
@@ -5,6 +7,14 @@ export default defineEndpoint({
     target: "server",
     description:
         "Clients should send this when they are ready to proceed with the found match. If not sent within 10s of the [found](#found) response then queue should be cancelled.",
-    request: {},
-    response: [{ status: "success" }, { status: "failed", reason: "no_match" }],
+    request: {
+        data: Type.Object({
+            queueId: Type.String(),
+        }),
+    },
+    response: [
+        { status: "success" },
+        { status: "failed", reason: "no_match" },
+        { status: "failed", reason: "invalid_queue_specified" },
+    ],
 });

--- a/src/schema/matchmaking/readyUpdate.ts
+++ b/src/schema/matchmaking/readyUpdate.ts
@@ -8,6 +8,7 @@ export default defineEndpoint({
     description: "Sent when a client in a found match readies up.",
     event: {
         data: Type.Object({
+            queueId: Type.Integer(),
             readyMax: Type.Integer(),
             readyCurrent: Type.Integer(),
         }),

--- a/test/cjs/validator.test.cts
+++ b/test/cjs/validator.test.cts
@@ -15,7 +15,7 @@ describe("request", () => {
             commandId: "matchmaking/queue",
             messageId: "123",
             data: {
-                queue: "1v1",
+                queueId: "1v1",
             },
         };
 
@@ -24,7 +24,7 @@ describe("request", () => {
         assert.equal(isValid, true);
 
         if (isValid) {
-            assert.equal(command.data.queue, "1v1");
+            assert.equal(command.data.queueId, "1v1");
         }
     });
 

--- a/test/esm/validator.test.mts
+++ b/test/esm/validator.test.mts
@@ -15,7 +15,7 @@ describe("request", () => {
             commandId: "matchmaking/queue",
             messageId: "123",
             data: {
-                queue: "1v1",
+                queueId: "1v1",
             },
         };
 
@@ -24,7 +24,7 @@ describe("request", () => {
         assert.equal(isValid, true);
 
         if (isValid) {
-            assert.equal(command.data.queue, "1v1");
+            assert.equal(command.data.queueId, "1v1");
         }
     });
 
@@ -35,7 +35,7 @@ describe("request", () => {
             messageId: "123",
             data: {
                 // @ts-expect-error
-                queues: [],
+                queueId: [],
             },
         };
 


### PR DESCRIPTION
Add `queueId` to requests and events

Each queue is treated independently so every event and request specific
to a given queue needs to include the ID of the queue.