### PR TITLE
Add matchmaking/cancelled event

### DIFF
--- a/docs/schema/matchmaking.md
+++ b/docs/schema/matchmaking.md
@@ -9,12 +9,16 @@ The matchmaking cycle works as follows:
 3. The server can send periodic updates about the status of the search as a [queueUpdate](#queueupdate) event.
 4. When a match is found, the server should send a [found](#found) event along with the id of the queue of the found match.
 5. Clients can then ready up by sending a [ready](#ready) request. The number of readied players should be sent to clients via the [readyUpdate](#readyupdate) event.
-6. To cancel queueing, or to decline a found match, clients should send a [cancel](#cancel) request.
+6. To cancel queueing, or to decline a found match, clients should send a [cancel](#cancel) request. After a successful `cancel` response, the server will also send a [cancelled](#cancelled) event.
 7. If a client fails to ready up for a found match, the server should send a [lost](#lost) event, and the queueing phase should resume.
 8. Once all players are ready, the server should send a [autohost/battleStart](#autohost/battleStart) request to a suitable autohost client. If the autohost doesn't respond quickly, or if it sends a failed response, the server should repeat this step.
 9. Once the autohost has successfully started the battle, the server should then send [battle/battleStart](#battle/battleStart) requests to the users.
+
+The server may send [matchmaking/cancelled](#cancelled) event at any point after the client sent a [queue](#queue) request with a reason. This means the client has been booted out the matchmaking system. It can happen for example when a party member leaves, or in case of a server error that needs to reset the matchmaking state. This event is also sent after a successful [cancel](#cancel) request.
+
 ---
 - [cancel](#cancel)
+- [cancelled](#cancelled)
 - [found](#found)
 - [foundUpdate](#foundupdate)
 - [list](#list)
@@ -157,6 +161,83 @@ Possible Failed Reasons: `not_queued`, `internal_error`, `unauthorized`, `invali
 
 ---
 
+## Cancelled
+
+Server may send this event at any point when the user is queuing to indicate that the user has been booted out the matchmaking system.
+
+- Endpoint Type: **Event**
+- Source: **Server**
+- Target: **User**
+- Required Scopes: `tachyon.lobby`
+
+### Event
+
+<details>
+<summary>JSONSchema</summary>
+
+```json
+{
+    "title": "MatchmakingCancelledEvent",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "event" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "matchmaking/cancelled" },
+        "data": {
+            "title": "MatchmakingCancelledEventData",
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "anyOf": [
+                        { "const": "intentional" },
+                        { "const": "server_error" },
+                        { "const": "party_user_left" }
+                    ]
+                }
+            },
+            "required": ["reason"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}
+
+```
+</details>
+
+<details>
+<summary>Example</summary>
+
+```json
+{
+    "type": "event",
+    "messageId": "voluptate ullamco",
+    "commandId": "matchmaking/cancelled",
+    "data": {
+        "reason": "intentional"
+    }
+}
+```
+</details>
+
+#### TypeScript Definition
+```ts
+export interface MatchmakingCancelledEvent {
+    type: "event";
+    messageId: string;
+    commandId: "matchmaking/cancelled";
+    data: MatchmakingCancelledEventData;
+}
+export interface MatchmakingCancelledEventData {
+    reason: "intentional" | "server_error" | "party_user_left";
+}
+```
+---
+
 ## Found
 
 Server should send this when there are enough queued players to form a valid battle that meets their criteria. Clients should then send [ready](#ready).
@@ -206,11 +287,11 @@ Server should send this when there are enough queued players to form a valid bat
 ```json
 {
     "type": "event",
-    "messageId": "voluptate ullamco",
+    "messageId": "in exercitation",
     "commandId": "matchmaking/found",
     "data": {
-        "queueId": "voluptate ullamco",
-        "timeoutMs": -50000000
+        "queueId": "in exercitation",
+        "timeoutMs": -48000000
     }
 }
 ```
@@ -277,10 +358,10 @@ Server should send this when players ready up using [ready](#ready).
 ```json
 {
     "type": "event",
-    "messageId": "in exercitation",
+    "messageId": "in nostrud",
     "commandId": "matchmaking/foundUpdate",
     "data": {
-        "readyCount": -48000000
+        "readyCount": -46000000
     }
 }
 ```
@@ -340,7 +421,7 @@ Returns all available matchmaking playlists.
 ```json
 {
     "type": "request",
-    "messageId": "in nostrud",
+    "messageId": "consequat quis",
     "commandId": "matchmaking/list"
 }
 ```
@@ -458,7 +539,7 @@ export interface MatchmakingListRequest {
 ```json
 {
     "type": "response",
-    "messageId": "consequat quis",
+    "messageId": "commodo laborum",
     "commandId": "matchmaking/list",
     "status": "success",
     "data": {
@@ -546,7 +627,7 @@ Sent when a found match gets disbanded because a client failed to ready up.
 ```json
 {
     "type": "event",
-    "messageId": "commodo laborum",
+    "messageId": "nisi deserunt",
     "commandId": "matchmaking/lost"
 }
 ```
@@ -614,12 +695,12 @@ Queue up for matchmaking. Should cancel the previous queue if already in one.
 ```json
 {
     "type": "request",
-    "messageId": "nisi deserunt",
+    "messageId": "nisi qui",
     "commandId": "matchmaking/queue",
     "data": {
         "queues": [
-            "nisi deserunt",
-            "nisi deserunt"
+            "nisi qui",
+            "nisi qui"
         ]
     }
 }
@@ -698,7 +779,7 @@ export interface MatchmakingQueueRequestData {
 ```json
 {
     "type": "response",
-    "messageId": "nisi qui",
+    "messageId": "laboris non",
     "commandId": "matchmaking/queue",
     "status": "success"
 }
@@ -764,10 +845,10 @@ Contains some info about the state of the current queue.
 ```json
 {
     "type": "event",
-    "messageId": "laboris non",
+    "messageId": "ullamco occaecat",
     "commandId": "matchmaking/queueUpdate",
     "data": {
-        "playersQueued": "laboris non"
+        "playersQueued": "ullamco occaecat"
     }
 }
 ```
@@ -827,7 +908,7 @@ Clients should send this when they are ready to proceed with the found match. If
 ```json
 {
     "type": "request",
-    "messageId": "ullamco occaecat",
+    "messageId": "reprehenderit Lorem",
     "commandId": "matchmaking/ready"
 }
 ```
@@ -899,7 +980,7 @@ export interface MatchmakingReadyRequest {
 ```json
 {
     "type": "response",
-    "messageId": "reprehenderit Lorem",
+    "messageId": "dolor Lorem",
     "commandId": "matchmaking/ready",
     "status": "success"
 }
@@ -968,11 +1049,11 @@ Sent when a client in a found match readies up.
 ```json
 {
     "type": "event",
-    "messageId": "dolor Lorem",
+    "messageId": "Duis Lorem",
     "commandId": "matchmaking/readyUpdate",
     "data": {
-        "readyMax": -30000000,
-        "readyCurrent": -30000000
+        "readyMax": -28000000,
+        "readyCurrent": -28000000
     }
 }
 ```

--- a/docs/schema/system.md
+++ b/docs/schema/system.md
@@ -52,10 +52,10 @@ Ask the server to terminate the connection.
 ```json
 {
     "type": "request",
-    "messageId": "Duis Lorem",
+    "messageId": "consequat Lorem",
     "commandId": "system/disconnect",
     "data": {
-        "reason": "Duis Lorem"
+        "reason": "consequat Lorem"
     }
 }
 ```
@@ -130,7 +130,7 @@ export interface SystemDisconnectRequestData {
 ```json
 {
     "type": "response",
-    "messageId": "consequat Lorem",
+    "messageId": "commodo Lorem",
     "commandId": "system/disconnect",
     "status": "success"
 }
@@ -190,7 +190,7 @@ Get server stats such as user count.
 ```json
 {
     "type": "request",
-    "messageId": "commodo Lorem",
+    "messageId": "ut Lorem",
     "commandId": "system/serverStats"
 }
 ```
@@ -267,11 +267,11 @@ export interface SystemServerStatsRequest {
 ```json
 {
     "type": "response",
-    "messageId": "ut Lorem",
+    "messageId": "occaecat Lorem in",
     "commandId": "system/serverStats",
     "status": "success",
     "data": {
-        "userCount": -22000000
+        "userCount": -20000000
     }
 }
 ```

--- a/docs/schema/user.md
+++ b/docs/schema/user.md
@@ -120,59 +120,59 @@ Sent by the server to inform the client when subscribed users get updated in som
 ```json
 {
     "type": "event",
-    "messageId": "occaecat Lorem in",
+    "messageId": "pariatur Lorem reprehenderit",
     "commandId": "user/updated",
     "data": {
         "users": [
             {
-                "occaecatff": -19999999.999999955,
+                "pariaturff": -17999999.999999955,
                 "userId": "f47a7e1e-4b2f-4d3d-3f3c-1f0f0e4b7e1e",
-                "username": "occaecat Lorem in",
+                "username": "pariatur Lorem reprehenderit",
                 "scopes": [
-                    "occaecat Lorem in",
-                    "occaecat Lorem in",
-                    "occaecat Lorem in"
+                    "pariatur Lorem reprehenderit",
+                    "pariatur Lorem reprehenderit",
+                    "pariatur Lorem reprehenderit"
                 ],
-                "countryCode": "occaecat Lorem in",
+                "countryCode": "pariatur Lorem reprehenderit",
                 "status": "menu",
                 "outgoingFriendRequestIds": [
-                    "occaecat Lorem in",
-                    "occaecat Lorem in",
-                    "occaecat Lorem in"
+                    "pariatur Lorem reprehenderit",
+                    "pariatur Lorem reprehenderit",
+                    "pariatur Lorem reprehenderit"
                 ]
             },
             {
-                "occaecatff": -19999999.999999955,
+                "pariaturff": -17999999.999999955,
                 "userId": "f47a7e1e-4b2f-4d3d-3f3c-1f0f0e4b7e1e",
-                "username": "occaecat Lorem in",
+                "username": "pariatur Lorem reprehenderit",
                 "scopes": [
-                    "occaecat Lorem in",
-                    "occaecat Lorem in",
-                    "occaecat Lorem in"
+                    "pariatur Lorem reprehenderit",
+                    "pariatur Lorem reprehenderit",
+                    "pariatur Lorem reprehenderit"
                 ],
-                "countryCode": "occaecat Lorem in",
+                "countryCode": "pariatur Lorem reprehenderit",
                 "status": "menu",
                 "outgoingFriendRequestIds": [
-                    "occaecat Lorem in",
-                    "occaecat Lorem in",
-                    "occaecat Lorem in"
+                    "pariatur Lorem reprehenderit",
+                    "pariatur Lorem reprehenderit",
+                    "pariatur Lorem reprehenderit"
                 ]
             },
             {
-                "occaecatff": -19999999.999999955,
+                "pariaturff": -17999999.999999955,
                 "userId": "f47a7e1e-4b2f-4d3d-3f3c-1f0f0e4b7e1e",
-                "username": "occaecat Lorem in",
+                "username": "pariatur Lorem reprehenderit",
                 "scopes": [
-                    "occaecat Lorem in",
-                    "occaecat Lorem in",
-                    "occaecat Lorem in"
+                    "pariatur Lorem reprehenderit",
+                    "pariatur Lorem reprehenderit",
+                    "pariatur Lorem reprehenderit"
                 ],
-                "countryCode": "occaecat Lorem in",
+                "countryCode": "pariatur Lorem reprehenderit",
                 "status": "menu",
                 "outgoingFriendRequestIds": [
-                    "occaecat Lorem in",
-                    "occaecat Lorem in",
-                    "occaecat Lorem in"
+                    "pariatur Lorem reprehenderit",
+                    "pariatur Lorem reprehenderit",
+                    "pariatur Lorem reprehenderit"
                 ]
             }
         ]

--- a/schema/compiled.json
+++ b/schema/compiled.json
@@ -1332,6 +1332,35 @@
             ]
         },
         {
+            "title": "MatchmakingCancelledEvent",
+            "tachyon": {
+                "source": "server",
+                "target": "user",
+                "scopes": ["tachyon.lobby"]
+            },
+            "type": "object",
+            "properties": {
+                "type": { "const": "event" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "matchmaking/cancelled" },
+                "data": {
+                    "title": "MatchmakingCancelledEventData",
+                    "type": "object",
+                    "properties": {
+                        "reason": {
+                            "anyOf": [
+                                { "const": "intentional" },
+                                { "const": "server_error" },
+                                { "const": "party_user_left" }
+                            ]
+                        }
+                    },
+                    "required": ["reason"]
+                }
+            },
+            "required": ["type", "messageId", "commandId", "data"]
+        },
+        {
             "title": "MatchmakingFoundEvent",
             "tachyon": {
                 "source": "server",

--- a/schema/matchmaking/cancelled/event.json
+++ b/schema/matchmaking/cancelled/event.json
@@ -1,0 +1,31 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/cancelled/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MatchmakingCancelledEvent",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "event" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "matchmaking/cancelled" },
+        "data": {
+            "title": "MatchmakingCancelledEventData",
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "anyOf": [
+                        { "const": "intentional" },
+                        { "const": "server_error" },
+                        { "const": "party_user_left" }
+                    ]
+                }
+            },
+            "required": ["reason"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/src/schema/matchmaking/README.md
+++ b/src/schema/matchmaking/README.md
@@ -5,7 +5,9 @@ The matchmaking cycle works as follows:
 3. The server can send periodic updates about the status of the search as a [queueUpdate](#queueupdate) event.
 4. When a match is found, the server should send a [found](#found) event along with the id of the queue of the found match.
 5. Clients can then ready up by sending a [ready](#ready) request. The number of readied players should be sent to clients via the [readyUpdate](#readyupdate) event.
-6. To cancel queueing, or to decline a found match, clients should send a [cancel](#cancel) request.
+6. To cancel queueing, or to decline a found match, clients should send a [cancel](#cancel) request. After a successful `cancel` response, the server will also send a [cancelled](#cancelled) event.
 7. If a client fails to ready up for a found match, the server should send a [lost](#lost) event, and the queueing phase should resume.
 8. Once all players are ready, the server should send a [autohost/battleStart](#autohost/battleStart) request to a suitable autohost client. If the autohost doesn't respond quickly, or if it sends a failed response, the server should repeat this step.
 9. Once the autohost has successfully started the battle, the server should then send [battle/battleStart](#battle/battleStart) requests to the users.
+
+The server may send [matchmaking/cancelled](#cancelled) event at any point after the client sent a [queue](#queue) request with a reason. This means the client has been booted out the matchmaking system. It can happen for example when a party member leaves, or in case of a server error that needs to reset the matchmaking state. This event is also sent after a successful [cancel](#cancel) request.

--- a/src/schema/matchmaking/cancelled.ts
+++ b/src/schema/matchmaking/cancelled.ts
@@ -1,0 +1,19 @@
+import { Type } from "@sinclair/typebox";
+
+import { defineEndpoint } from "@/generator-helpers.js";
+
+export default defineEndpoint({
+    source: "server",
+    target: "user",
+    description:
+        "Server may send this event at any point when the user is queuing to indicate that the user has been booted out the matchmaking system.",
+    event: {
+        data: Type.Object({
+            reason: Type.Union([
+                Type.Literal("intentional"),
+                Type.Literal("server_error"),
+                Type.Literal("party_user_left"),
+            ]),
+        }),
+    },
+});


### PR DESCRIPTION
Adding an event to boot a player out of matchmaking. 2 reasons I can see where this is needed:

1. a party member leave the matchmaking, and thus other party members are evicted
2. server's component crash. If something goes wrong and the server cannot recover the matchmaking state of the player, it's better to eject them so they can retry/reset. 