### PR TITLE
Add matchmaking cancelled timeout reason

### DIFF
--- a/docs/schema/matchmaking.md
+++ b/docs/schema/matchmaking.md
@@ -193,7 +193,12 @@ Server may send this event at any point when the user is queuing to indicate tha
             "type": "object",
             "properties": {
                 "reason": {
-                    "enum": ["intentional", "server_error", "party_user_left"]
+                    "enum": [
+                        "intentional",
+                        "server_error",
+                        "party_user_left",
+                        "ready_timeout"
+                    ]
                 }
             },
             "required": ["reason"]
@@ -214,7 +219,7 @@ Server may send this event at any point when the user is queuing to indicate tha
     "messageId": "voluptate ullamco",
     "commandId": "matchmaking/cancelled",
     "data": {
-        "reason": "intentional"
+        "reason": "server_error"
     }
 }
 ```
@@ -229,7 +234,7 @@ export interface MatchmakingCancelledEvent {
     data: MatchmakingCancelledEventData;
 }
 export interface MatchmakingCancelledEventData {
-    reason: "intentional" | "server_error" | "party_user_left";
+    reason: "intentional" | "server_error" | "party_user_left" | "ready_timeout";
 }
 ```
 ---

--- a/docs/schema/matchmaking.md
+++ b/docs/schema/matchmaking.md
@@ -16,6 +16,15 @@ The matchmaking cycle works as follows:
 
 The server may send [matchmaking/cancelled](#cancelled) event at any point after the client sent a [queue](#queue) request with a reason. This means the client has been booted out the matchmaking system. It can happen for example when a party member leaves, or in case of a server error that needs to reset the matchmaking state. This event is also sent after a successful [cancel](#cancel) request.
 
+[matchmaking/cancelled](#cancelled) can have the following reasons:
+* `intentional`: the player left matchmaking
+* `server_error`: something bad happended and the server couldn't maintain
+  state so it booted the player out. Retrying may fix the issue.
+* `party_user_left`: a member of the player's party left matchmaking, thus
+  forcing the entire party to withdraw
+* `ready_timeout`: The player failed to accept a match within the given
+  time window and is thus removed from the matchmaking system.
+
 ---
 - [cancel](#cancel)
 - [cancelled](#cancelled)

--- a/schema/compiled.json
+++ b/schema/compiled.json
@@ -1344,7 +1344,8 @@
                             "enum": [
                                 "intentional",
                                 "server_error",
-                                "party_user_left"
+                                "party_user_left",
+                                "ready_timeout"
                             ]
                         }
                     },

--- a/schema/matchmaking/cancelled/event.json
+++ b/schema/matchmaking/cancelled/event.json
@@ -17,7 +17,12 @@
             "type": "object",
             "properties": {
                 "reason": {
-                    "enum": ["intentional", "server_error", "party_user_left"]
+                    "enum": [
+                        "intentional",
+                        "server_error",
+                        "party_user_left",
+                        "ready_timeout"
+                    ]
                 }
             },
             "required": ["reason"]

--- a/src/schema/matchmaking/README.md
+++ b/src/schema/matchmaking/README.md
@@ -11,3 +11,12 @@ The matchmaking cycle works as follows:
 9. Once the autohost has successfully started the battle, the server should then send [battle/battleStart](#battle/battleStart) requests to the users.
 
 The server may send [matchmaking/cancelled](#cancelled) event at any point after the client sent a [queue](#queue) request with a reason. This means the client has been booted out the matchmaking system. It can happen for example when a party member leaves, or in case of a server error that needs to reset the matchmaking state. This event is also sent after a successful [cancel](#cancel) request.
+
+[matchmaking/cancelled](#cancelled) can have the following reasons:
+* `intentional`: the player left matchmaking
+* `server_error`: something bad happended and the server couldn't maintain
+  state so it booted the player out. Retrying may fix the issue.
+* `party_user_left`: a member of the player's party left matchmaking, thus
+  forcing the entire party to withdraw
+* `ready_timeout`: The player failed to accept a match within the given
+  time window and is thus removed from the matchmaking system.

--- a/src/schema/matchmaking/cancelled.ts
+++ b/src/schema/matchmaking/cancelled.ts
@@ -10,7 +10,7 @@ export default defineEndpoint({
         "Server may send this event at any point when the user is queuing to indicate that the user has been booted out the matchmaking system.",
     event: {
         data: Type.Object({
-            reason: UnionEnum(["intentional", "server_error", "party_user_left"]),
+            reason: UnionEnum(["intentional", "server_error", "party_user_left", "ready_timeout"]),
         }),
     },
 });


### PR DESCRIPTION
Add a new `cancelled` reason for when a player fails to ready up in time.
Leaving afk players in matchmaking queues could introduce "poison pills": some match would get prepared to only repeatedly fails. So it's better to just boot them out.