### PR TITLE
Add system/disconnected event

### DIFF
--- a/docs/schema/system.md
+++ b/docs/schema/system.md
@@ -2,6 +2,24 @@
 
 # System
 
+System commands to manage the connection itself and get updates from the server.
+
+* [disconnect](#disconnect) is the event to send to the server before
+stopping the connection. If the client closes the connection without first
+sending this event, it will be considered as a client crash by the server.
+
+* [disconnected](#disconnected) is the dual of `disconnect` where the server
+is terminating the connection and disconnecting the user. This can happen
+if the server detects a timeout, either because no activity on the connection
+or the server is expecting a response to a request and hasn't received it (and
+all potential retries have been exhausted). `server_error` is sent when the
+server encountered a fatal error for the user and the only way to recover is
+to reconnect.
+
+* [serverStats](#serverStats) can be used to request generic, user facing data
+about the server like number of connecting players.
+
+---
 - [disconnect](#disconnect)
 - [serverStats](#serverstats)
 ---

--- a/schema/system/disconnected/event.json
+++ b/schema/system/disconnected/event.json
@@ -1,0 +1,28 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/system/disconnected/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "SystemDisconnectedEvent",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "event" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "system/disconnected" },
+        "data": {
+            "title": "SystemDisconnectedEventData",
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "enum": ["protocol_violation", "server_error", "timeout"]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["reason"]
+        }
+    },
+    "required": ["type", "messageId", "commandId"]
+}

--- a/src/schema/system/README.md
+++ b/src/schema/system/README.md
@@ -1,0 +1,16 @@
+System commands to manage the connection itself and get updates from the server.
+
+* [disconnect](#disconnect) is the event to send to the server before
+stopping the connection. If the client closes the connection without first
+sending this event, it will be considered as a client crash by the server.
+
+* [disconnected](#disconnected) is the dual of `disconnect` where the server
+is terminating the connection and disconnecting the user. This can happen
+if the server detects a timeout, either because no activity on the connection
+or the server is expecting a response to a request and hasn't received it (and
+all potential retries have been exhausted). `server_error` is sent when the
+server encountered a fatal error for the user and the only way to recover is
+to reconnect.
+
+* [serverStats](#serverStats) can be used to request generic, user facing data
+about the server like number of connecting players.


### PR DESCRIPTION
While working on the matchmaking I noticed this event was missing.
It's not strictly necessary for now but it's better to have clean disconnection.