### PR TITLE
Remove uuid format for user id

### DIFF
--- a/schema/definitions/userId.json
+++ b/schema/definitions/userId.json
@@ -2,6 +2,5 @@
     "$id": "https://schema.beyondallreason.dev/tachyon/definitions/userId.json",
     "title": "UserId",
     "type": "string",
-    "format": "uuid",
-    "examples": ["f47a7e1e-4b2f-4d3d-3f3c-1f0f0e4b7e1e"]
+    "examples": ["1281"]
 }


### PR DESCRIPTION
These are opaque string, no need to force a uuid, especially since the server uses integer.