### PR TITLE
Add party id to message received

### DIFF
--- a/docs/schema/messaging.md
+++ b/docs/schema/messaging.md
@@ -85,8 +85,13 @@ Notify the player a message has been received
                         },
                         {
                             "type": "object",
-                            "properties": { "type": { "const": "party" } },
-                            "required": ["type"]
+                            "properties": {
+                                "type": { "const": "party" },
+                                "partyId": {
+                                    "$ref": "../../definitions/partyId.json"
+                                }
+                            },
+                            "required": ["type", "partyId"]
                         }
                     ]
                 },
@@ -129,6 +134,7 @@ Notify the player a message has been received
 #### TypeScript Definition
 ```ts
 export type UserId = string;
+export type PartyId = string;
 export type HistoryMarker = string;
 
 export interface MessagingReceivedEvent {
@@ -146,6 +152,7 @@ export interface MessagingReceivedEventData {
           }
         | {
               type: "party";
+              partyId: PartyId;
           };
     timestamp: number;
     marker: HistoryMarker;

--- a/schema/compiled.json
+++ b/schema/compiled.json
@@ -2595,9 +2595,12 @@
                                 {
                                     "type": "object",
                                     "properties": {
-                                        "type": { "const": "party" }
+                                        "type": { "const": "party" },
+                                        "partyId": {
+                                            "$ref": "#/definitions/partyId"
+                                        }
                                     },
-                                    "required": ["type"]
+                                    "required": ["type", "partyId"]
                                 }
                             ]
                         },

--- a/schema/messaging/received/event.json
+++ b/schema/messaging/received/event.json
@@ -31,8 +31,13 @@
                         },
                         {
                             "type": "object",
-                            "properties": { "type": { "const": "party" } },
-                            "required": ["type"]
+                            "properties": {
+                                "type": { "const": "party" },
+                                "partyId": {
+                                    "$ref": "../../definitions/partyId.json"
+                                }
+                            },
+                            "required": ["type", "partyId"]
                         }
                     ]
                 },

--- a/src/schema/messaging/received.ts
+++ b/src/schema/messaging/received.ts
@@ -2,6 +2,7 @@ import { Type } from "@sinclair/typebox";
 
 import { defineEndpoint } from "@/generator-helpers.js";
 import { historyMarker } from "@/schema/definitions/historyMarker";
+import { partyId } from "@/schema/definitions/partyId";
 import { unixTime } from "@/schema/definitions/unixTime";
 import { userId } from "@/schema/definitions/userId";
 
@@ -19,6 +20,7 @@ export default defineEndpoint({
                 }),
                 Type.Object({
                     type: Type.Literal("party"),
+                    partyId: Type.Ref(partyId),
                 }),
             ]),
             timestamp: Type.Ref(unixTime, {


### PR DESCRIPTION
Relying on the current party isn't correct because there's history for messages. So a player could be in a party, then change party, and only then subscribe to the messages. There would be no way for them to know which messages belong to which party.