### PR TITLE
Add player id in source message in party

### DIFF
--- a/docs/schema/messaging.md
+++ b/docs/schema/messaging.md
@@ -89,9 +89,12 @@ Notify the player a message has been received
                                 "type": { "const": "party" },
                                 "partyId": {
                                     "$ref": "../../definitions/partyId.json"
+                                },
+                                "userId": {
+                                    "$ref": "../../definitions/userId.json"
                                 }
                             },
-                            "required": ["type", "partyId"]
+                            "required": ["type", "partyId", "userId"]
                         }
                     ]
                 },
@@ -153,6 +156,7 @@ export interface MessagingReceivedEventData {
         | {
               type: "party";
               partyId: PartyId;
+              userId: UserId;
           };
     timestamp: number;
     marker: HistoryMarker;

--- a/schema/compiled.json
+++ b/schema/compiled.json
@@ -2598,9 +2598,12 @@
                                         "type": { "const": "party" },
                                         "partyId": {
                                             "$ref": "#/definitions/partyId"
+                                        },
+                                        "userId": {
+                                            "$ref": "#/definitions/userId"
                                         }
                                     },
-                                    "required": ["type", "partyId"]
+                                    "required": ["type", "partyId", "userId"]
                                 }
                             ]
                         },

--- a/schema/messaging/received/event.json
+++ b/schema/messaging/received/event.json
@@ -35,9 +35,12 @@
                                 "type": { "const": "party" },
                                 "partyId": {
                                     "$ref": "../../definitions/partyId.json"
+                                },
+                                "userId": {
+                                    "$ref": "../../definitions/userId.json"
                                 }
                             },
-                            "required": ["type", "partyId"]
+                            "required": ["type", "partyId", "userId"]
                         }
                     ]
                 },

--- a/src/schema/messaging/received.ts
+++ b/src/schema/messaging/received.ts
@@ -21,6 +21,7 @@ export default defineEndpoint({
                 Type.Object({
                     type: Type.Literal("party"),
                     partyId: Type.Ref(partyId),
+                    userId: Type.Ref(userId),
                 }),
             ]),
             timestamp: Type.Ref(unixTime, {


### PR DESCRIPTION
Knowing a message is coming from a party is useful, but not enough for a client to be able to display the sender in a meaningful way, oops.