### PR TITLE
Fix UserSubscribeUpdatesRequestData typing

### DIFF
--- a/docs/schema/user.md
+++ b/docs/schema/user.md
@@ -475,7 +475,7 @@ export interface PrivateBattle {
 
 ## SubscribeUpdates
 
-Ask the server to send updates about theses users.
+Ask the server to send updates about theses users. A maximum of 100 userIds can be subscribed to at any given time.
 
 - Endpoint Type: **Request** -> **Response**
 - Source: **User**
@@ -697,13 +697,7 @@ Ask the server to stop sending user updates for the given set of userId. This sh
             "properties": {
                 "userIds": {
                     "type": "array",
-                    "items": {
-                        "$id": "userId",
-                        "type": "string",
-                        "examples": ["351"]
-                    },
-                    "minItems": 1,
-                    "maxItems": 100
+                    "items": { "$ref": "../../definitions/userId.json" }
                 }
             },
             "required": ["userIds"]
@@ -725,21 +719,6 @@ Ask the server to stop sending user updates for the given set of userId. This sh
     "commandId": "user/unsubscribeUpdates",
     "data": {
         "userIds": [
-            "351",
-            "351",
-            "351",
-            "351",
-            "351",
-            "351",
-            "351",
-            "351",
-            "351",
-            "351",
-            "351",
-            "351",
-            "351",
-            "351",
-            "351",
             "351"
         ]
     }
@@ -758,7 +737,7 @@ export interface UserUnsubscribeUpdatesRequest {
     data: UserUnsubscribeUpdatesRequestData;
 }
 export interface UserUnsubscribeUpdatesRequestData {
-    userIds: [UserId, ...UserId[]];
+    userIds: UserId[];
 }
 ```
 ### Response

--- a/docs/schema/user.md
+++ b/docs/schema/user.md
@@ -506,11 +506,7 @@ Ask the server to send updates about theses users. A maximum of 100 userIds can 
             "properties": {
                 "userIds": {
                     "type": "array",
-                    "items": {
-                        "$id": "userId",
-                        "type": "string",
-                        "examples": ["351"]
-                    },
+                    "items": { "$ref": "../../definitions/userId.json" },
                     "minItems": 1,
                     "maxItems": 100
                 }
@@ -697,7 +693,9 @@ Ask the server to stop sending user updates for the given set of userId. This sh
             "properties": {
                 "userIds": {
                     "type": "array",
-                    "items": { "$ref": "../../definitions/userId.json" }
+                    "items": { "$ref": "../../definitions/userId.json" },
+                    "minItems": 1,
+                    "maxItems": 100
                 }
             },
             "required": ["userIds"]
@@ -719,6 +717,21 @@ Ask the server to stop sending user updates for the given set of userId. This sh
     "commandId": "user/unsubscribeUpdates",
     "data": {
         "userIds": [
+            "351",
+            "351",
+            "351",
+            "351",
+            "351",
+            "351",
+            "351",
+            "351",
+            "351",
+            "351",
+            "351",
+            "351",
+            "351",
+            "351",
+            "351",
             "351"
         ]
     }
@@ -737,7 +750,7 @@ export interface UserUnsubscribeUpdatesRequest {
     data: UserUnsubscribeUpdatesRequestData;
 }
 export interface UserUnsubscribeUpdatesRequestData {
-    userIds: UserId[];
+    userIds: [UserId, ...UserId[]];
 }
 ```
 ### Response

--- a/schema/compiled.json
+++ b/schema/compiled.json
@@ -3646,11 +3646,7 @@
                     "properties": {
                         "userIds": {
                             "type": "array",
-                            "items": {
-                                "$id": "userId",
-                                "type": "string",
-                                "examples": ["351"]
-                            },
+                            "items": { "$ref": "#/definitions/userId" },
                             "minItems": 1,
                             "maxItems": 100
                         }
@@ -3726,7 +3722,9 @@
                     "properties": {
                         "userIds": {
                             "type": "array",
-                            "items": { "$ref": "#/definitions/userId" }
+                            "items": { "$ref": "#/definitions/userId" },
+                            "minItems": 1,
+                            "maxItems": 100
                         }
                     },
                     "required": ["userIds"]

--- a/schema/compiled.json
+++ b/schema/compiled.json
@@ -3726,13 +3726,7 @@
                     "properties": {
                         "userIds": {
                             "type": "array",
-                            "items": {
-                                "$id": "userId",
-                                "type": "string",
-                                "examples": ["351"]
-                            },
-                            "minItems": 1,
-                            "maxItems": 100
+                            "items": { "$ref": "#/definitions/userId" }
                         }
                     },
                     "required": ["userIds"]

--- a/schema/user/subscribeUpdates/request.json
+++ b/schema/user/subscribeUpdates/request.json
@@ -18,11 +18,7 @@
             "properties": {
                 "userIds": {
                     "type": "array",
-                    "items": {
-                        "$id": "userId",
-                        "type": "string",
-                        "examples": ["351"]
-                    },
+                    "items": { "$ref": "../../definitions/userId.json" },
                     "minItems": 1,
                     "maxItems": 100
                 }

--- a/schema/user/unsubscribeUpdates/request.json
+++ b/schema/user/unsubscribeUpdates/request.json
@@ -18,7 +18,9 @@
             "properties": {
                 "userIds": {
                     "type": "array",
-                    "items": { "$ref": "../../definitions/userId.json" }
+                    "items": { "$ref": "../../definitions/userId.json" },
+                    "minItems": 1,
+                    "maxItems": 100
                 }
             },
             "required": ["userIds"]

--- a/schema/user/unsubscribeUpdates/request.json
+++ b/schema/user/unsubscribeUpdates/request.json
@@ -18,13 +18,7 @@
             "properties": {
                 "userIds": {
                     "type": "array",
-                    "items": {
-                        "$id": "userId",
-                        "type": "string",
-                        "examples": ["351"]
-                    },
-                    "minItems": 1,
-                    "maxItems": 100
+                    "items": { "$ref": "../../definitions/userId.json" }
                 }
             },
             "required": ["userIds"]

--- a/src/generate-ts-defs.ts
+++ b/src/generate-ts-defs.ts
@@ -14,6 +14,7 @@ export async function generateTSDefs() {
             tabWidth: 4,
             semi: true,
         },
+        ignoreMinAndMaxItems: true,
     });
 
     await fs.writeFile(`dist/types.ts`, typings);

--- a/src/schema/user/subscribeUpdates.ts
+++ b/src/schema/user/subscribeUpdates.ts
@@ -10,7 +10,7 @@ export default defineEndpoint({
         "Ask the server to send updates about theses users. A maximum of 100 userIds can be subscribed to at any given time.",
     request: {
         data: Type.Object({
-            userIds: Type.Array(userId, { minItems: 1, maxItems: 100 }),
+            userIds: Type.Array(Type.Ref(userId), { minItems: 1, maxItems: 100 }),
         }),
     },
     response: [

--- a/src/schema/user/subscribeUpdates.ts
+++ b/src/schema/user/subscribeUpdates.ts
@@ -6,7 +6,8 @@ import { userId } from "@/schema/definitions/userId";
 export default defineEndpoint({
     source: "user",
     target: "server",
-    description: "Ask the server to send updates about theses users.",
+    description:
+        "Ask the server to send updates about theses users. A maximum of 100 userIds can be subscribed to at any given time.",
     request: {
         data: Type.Object({
             userIds: Type.Array(userId, { minItems: 1, maxItems: 100 }),

--- a/src/schema/user/unsubscribeUpdates.ts
+++ b/src/schema/user/unsubscribeUpdates.ts
@@ -10,7 +10,7 @@ export default defineEndpoint({
         "Ask the server to stop sending user updates for the given set of userId. This should always succeed.",
     request: {
         data: Type.Object({
-            userIds: Type.Array(userId, { minItems: 1, maxItems: 100 }),
+            userIds: Type.Array(Type.Ref(userId)),
         }),
     },
     response: [

--- a/src/schema/user/unsubscribeUpdates.ts
+++ b/src/schema/user/unsubscribeUpdates.ts
@@ -10,7 +10,7 @@ export default defineEndpoint({
         "Ask the server to stop sending user updates for the given set of userId. This should always succeed.",
     request: {
         data: Type.Object({
-            userIds: Type.Array(Type.Ref(userId)),
+            userIds: Type.Array(Type.Ref(userId), { minItems: 1, maxItems: 100 }),
         }),
     },
     response: [


### PR DESCRIPTION
The typing for UserSubscribeUpdatesRequestData and UserUnsubscribeUpdatesRequestData is wrong.

1. UserId shouldn't be redefined.
2. minItems / maxItems messes up the type generation

```
type UserId1 = string;
type UserId2 = string;

interface UserSubscribeUpdatesRequestData {
    /**
     * @minItems 1
     * @maxItems 100
     */
    userIds: [UserId1, ...UserId1[]];
}

interface UserUnsubscribeUpdatesRequestData {
    /**
     * @minItems 1
     * @maxItems 100
     */
    userIds: [UserId2, ...UserId2[]];
}
```

after:
```
interface UserSubscribeUpdatesRequestData {
    userIds: UserId[];
}

interface UserUnsubscribeUpdatesRequestData {
    userIds: UserId[];
}
```