### PR TITLE
Add hostUserId to lobby/updated

### DIFF
--- a/docs/schema/lobby.md
+++ b/docs/schema/lobby.md
@@ -2707,6 +2707,9 @@ Sent by the server whenever something in the lobby changes. Uses json patch (RFC
                                     "type": "object",
                                     "properties": {
                                         "id": { "type": "string" },
+                                        "hostUserId": {
+                                            "$ref": "#/definitions/userId"
+                                        },
                                         "allyTeam": { "type": "string" },
                                         "team": { "type": "string" },
                                         "player": { "type": "string" },
@@ -2896,6 +2899,7 @@ export interface LobbyUpdatedEventData {
     bots?: {
         [k: string]: {
             id: string;
+            hostUserId?: UserId;
             allyTeam?: string;
             team?: string;
             player?: string;

--- a/schema/compiled.json
+++ b/schema/compiled.json
@@ -3390,6 +3390,9 @@
                                             "type": "object",
                                             "properties": {
                                                 "id": { "type": "string" },
+                                                "hostUserId": {
+                                                    "$ref": "#/definitions/userId"
+                                                },
                                                 "allyTeam": {
                                                     "type": "string"
                                                 },

--- a/schema/lobby/updated/event.json
+++ b/schema/lobby/updated/event.json
@@ -120,6 +120,9 @@
                                     "type": "object",
                                     "properties": {
                                         "id": { "type": "string" },
+                                        "hostUserId": {
+                                            "$ref": "../../definitions/userId.json"
+                                        },
                                         "allyTeam": { "type": "string" },
                                         "team": { "type": "string" },
                                         "player": { "type": "string" },

--- a/src/schema/lobby/updated.ts
+++ b/src/schema/lobby/updated.ts
@@ -81,6 +81,7 @@ export default defineEndpoint({
                     Nullable(
                         Type.Object({
                             id: Type.String(),
+                            hostUserId: Type.Optional(Type.Ref("userId")),
                             allyTeam: Type.Optional(Type.String()),
                             team: Type.Optional(Type.String()),
                             player: Type.Optional(Type.String()),


### PR DESCRIPTION
Required for clients to show which bots are bound to which users since when the host leaves, the bots are also removed.