### PR TITLE
Add `version` to matchmaking playlists.

### DIFF
--- a/schema/compiled.json
+++ b/schema/compiled.json
@@ -3629,7 +3629,8 @@
                                 "intentional",
                                 "server_error",
                                 "party_user_left",
-                                "ready_timeout"
+                                "ready_timeout",
+                                "version_changed"
                             ]
                         }
                     },
@@ -3724,6 +3725,10 @@
                                         "type": "object",
                                         "properties": {
                                             "id": { "type": "string" },
+                                            "version": {
+                                                "description": "Opaque version string that uniquely identifies the properties of the queue with this id, including list of required assets versions",
+                                                "type": "string"
+                                            },
                                             "name": { "type": "string" },
                                             "numOfTeams": { "type": "integer" },
                                             "teamSize": { "type": "integer" },
@@ -3767,6 +3772,7 @@
                                         },
                                         "required": [
                                             "id",
+                                            "version",
                                             "name",
                                             "numOfTeams",
                                             "teamSize",
@@ -3784,6 +3790,7 @@
                                     "playlists": [
                                         {
                                             "id": "1v1",
+                                            "version": "27n6cr76nyfqic73647c1328c94",
                                             "name": "Duel",
                                             "numOfTeams": 2,
                                             "teamSize": 1,
@@ -3900,11 +3907,28 @@
                     "properties": {
                         "queues": {
                             "type": "array",
-                            "items": { "type": "string" },
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "id": { "type": "string" },
+                                    "version": { "type": "string" }
+                                },
+                                "required": ["id", "version"]
+                            },
                             "minItems": 1
                         }
                     },
-                    "required": ["queues"]
+                    "required": ["queues"],
+                    "examples": [
+                        {
+                            "queues": [
+                                {
+                                    "id": "1v1",
+                                    "version": "27n6cr76nyfqic73647c1328c94"
+                                }
+                            ]
+                        }
+                    ]
                 }
             },
             "required": ["type", "messageId", "commandId", "data"]
@@ -3941,6 +3965,7 @@
                                 "invalid_queue_specified",
                                 "already_queued",
                                 "already_in_battle",
+                                "version_mismatch",
                                 "internal_error",
                                 "unauthorized",
                                 "invalid_request",

--- a/schema/matchmaking/cancelled/event.json
+++ b/schema/matchmaking/cancelled/event.json
@@ -21,7 +21,8 @@
                         "intentional",
                         "server_error",
                         "party_user_left",
-                        "ready_timeout"
+                        "ready_timeout",
+                        "version_changed"
                     ]
                 }
             },

--- a/schema/matchmaking/list/response.json
+++ b/schema/matchmaking/list/response.json
@@ -26,6 +26,10 @@
                                 "type": "object",
                                 "properties": {
                                     "id": { "type": "string" },
+                                    "version": {
+                                        "description": "Opaque version string that uniquely identifies the properties of the queue with this id, including list of required assets versions",
+                                        "type": "string"
+                                    },
                                     "name": { "type": "string" },
                                     "numOfTeams": { "type": "integer" },
                                     "teamSize": { "type": "integer" },
@@ -67,6 +71,7 @@
                                 },
                                 "required": [
                                     "id",
+                                    "version",
                                     "name",
                                     "numOfTeams",
                                     "teamSize",
@@ -84,6 +89,7 @@
                             "playlists": [
                                 {
                                     "id": "1v1",
+                                    "version": "27n6cr76nyfqic73647c1328c94",
                                     "name": "Duel",
                                     "numOfTeams": 2,
                                     "teamSize": 1,

--- a/schema/matchmaking/queue/request.json
+++ b/schema/matchmaking/queue/request.json
@@ -18,11 +18,28 @@
             "properties": {
                 "queues": {
                     "type": "array",
-                    "items": { "type": "string" },
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": { "type": "string" },
+                            "version": { "type": "string" }
+                        },
+                        "required": ["id", "version"]
+                    },
                     "minItems": 1
                 }
             },
-            "required": ["queues"]
+            "required": ["queues"],
+            "examples": [
+                {
+                    "queues": [
+                        {
+                            "id": "1v1",
+                            "version": "27n6cr76nyfqic73647c1328c94"
+                        }
+                    ]
+                }
+            ]
         }
     },
     "required": ["type", "messageId", "commandId", "data"]

--- a/schema/matchmaking/queue/response.json
+++ b/schema/matchmaking/queue/response.json
@@ -32,6 +32,7 @@
                         "invalid_queue_specified",
                         "already_queued",
                         "already_in_battle",
+                        "version_mismatch",
                         "internal_error",
                         "unauthorized",
                         "invalid_request",

--- a/src/schema/matchmaking/README.md
+++ b/src/schema/matchmaking/README.md
@@ -1,7 +1,7 @@
 The matchmaking cycle works as follows:
 
 1. Clients should first retrieve a list of all the available queues from the server using [list](#list).
-2. Clients should then queue for one or more of these queues by sending an array of the queue ids in a [queue](#queue) request.
+2. Clients should then queue for one or more of these queues by sending an array of the queue ids in a [queue](#queue) request. Before joining the queue, the client needs to download all required assets to make sure that `ready` can be send instantly.
 3. The server can send periodic updates about the status of the search as a [queueUpdate](#queueupdate) event.
 4. When a match is found, the server should send a [found](#found) event along with the id of the queue of the found match.
 5. Clients can then ready up by sending a [ready](#ready) request. The number of readied players should be sent to clients via the [foundUpdate](#foundupdate) event.
@@ -10,7 +10,7 @@ The matchmaking cycle works as follows:
 8. Once all players are ready, the server should send a [autohost/battleStart](#autohost/battleStart) request to a suitable autohost client. If the autohost doesn't respond quickly, or if it sends a failed response, the server should repeat this step.
 9. Once the autohost has successfully started the battle, the server should then send [battle/battleStart](#battle/battleStart) requests to the users.
 
-The server may send [matchmaking/cancelled](#cancelled) event at any point after the client sent a [queue](#queue) request with a reason. This means the client has been booted out the matchmaking system. It can happen for example when a party member leaves, or in case of a server error that needs to reset the matchmaking state. This event is also sent after a successful [cancel](#cancel) request.
+The server may send [matchmaking/cancelled](#cancelled) event at any point after the client sent a [queue](#queue) request with a reason. This means the client has been booted out the matchmaking system. It can happen for example when a party member leaves, or in case of a server error that needs to reset the matchmaking state, or if list of required assets changed. This event is also sent after a successful [cancel](#cancel) request.
 
 [matchmaking/cancelled](#cancelled) can have the following reasons:
 * `intentional`: the player left matchmaking

--- a/src/schema/matchmaking/cancelled.ts
+++ b/src/schema/matchmaking/cancelled.ts
@@ -10,7 +10,13 @@ export default defineEndpoint({
         "Server may send this event at any point when the user is queuing to indicate that the user has been booted out the matchmaking system.",
     event: {
         data: Type.Object({
-            reason: UnionEnum(["intentional", "server_error", "party_user_left", "ready_timeout"]),
+            reason: UnionEnum([
+                "intentional",
+                "server_error",
+                "party_user_left",
+                "ready_timeout",
+                "version_changed",
+            ]),
         }),
     },
 });

--- a/src/schema/matchmaking/list.ts
+++ b/src/schema/matchmaking/list.ts
@@ -15,6 +15,10 @@ export default defineEndpoint({
                     playlists: Type.Array(
                         Type.Object({
                             id: Type.String(),
+                            version: Type.String({
+                                description:
+                                    "Opaque version string that uniquely identifies the properties of the queue with this id, including list of required assets versions",
+                            }),
                             name: Type.String(),
                             numOfTeams: Type.Integer(),
                             teamSize: Type.Integer(),
@@ -43,6 +47,7 @@ export default defineEndpoint({
                             playlists: [
                                 {
                                     id: "1v1",
+                                    version: "27n6cr76nyfqic73647c1328c94",
                                     name: "Duel",
                                     numOfTeams: 2,
                                     teamSize: 1,

--- a/src/schema/matchmaking/queue.ts
+++ b/src/schema/matchmaking/queue.ts
@@ -7,14 +7,35 @@ export default defineEndpoint({
     target: "server",
     description: "Queue up for matchmaking. Should cancel the previous queue if already in one.",
     request: {
-        data: Type.Object({
-            queues: Type.Array(Type.String(), { minItems: 1 }),
-        }),
+        data: Type.Object(
+            {
+                queues: Type.Array(
+                    Type.Object({
+                        id: Type.String(),
+                        version: Type.String(),
+                    }),
+                    { minItems: 1 }
+                ),
+            },
+            {
+                examples: [
+                    {
+                        queues: [
+                            {
+                                id: "1v1",
+                                version: "27n6cr76nyfqic73647c1328c94",
+                            },
+                        ],
+                    },
+                ],
+            }
+        ),
     },
     response: [
         { status: "success" },
         { status: "failed", reason: "invalid_queue_specified" },
         { status: "failed", reason: "already_queued" },
         { status: "failed", reason: "already_in_battle" },
+        { status: "failed", reason: "version_mismatch" },
     ],
 });

--- a/test/cjs/validator.test.cts
+++ b/test/cjs/validator.test.cts
@@ -15,7 +15,12 @@ describe("request", () => {
             commandId: "matchmaking/queue",
             messageId: "123",
             data: {
-                queues: ["1v1"],
+                queues: [
+                    {
+                        id: "1v1",
+                        version: "238949234",
+                    },
+                ],
             },
         };
 
@@ -24,7 +29,7 @@ describe("request", () => {
         assert.equal(isValid, true);
 
         if (isValid) {
-            assert.equal(command.data.queues[0], "1v1");
+            assert.equal(command.data.queues[0].id, "1v1");
         }
     });
 

--- a/test/esm/validator.test.mts
+++ b/test/esm/validator.test.mts
@@ -15,7 +15,12 @@ describe("request", () => {
             commandId: "matchmaking/queue",
             messageId: "123",
             data: {
-                queues: ["1v1"],
+                queues: [
+                    {
+                        id: "1v1",
+                        version: "238949234",
+                    },
+                ],
             },
         };
 
@@ -24,7 +29,7 @@ describe("request", () => {
         assert.equal(isValid, true);
 
         if (isValid) {
-            assert.equal(command.data.queues[0], "1v1");
+            assert.equal(command.data.queues[0].id, "1v1");
         }
     });
 


### PR DESCRIPTION
This allows the client and server to detect the mismatch between the playlist definition. This solves the race condition between client fetching list of playlists and joining queue that could cause client to miss required assets.