### PR TITLE
Fix schema generation with embedded definitions

### DIFF
--- a/docs/schema/autohost.md
+++ b/docs/schema/autohost.md
@@ -76,6 +76,8 @@ Request to add a new player to the battle.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/addPlayer/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostAddPlayerRequest",
     "tachyon": {
         "source": "server",
@@ -92,7 +94,7 @@ Request to add a new player to the battle.
             "type": "object",
             "properties": {
                 "battleId": { "type": "string", "format": "uuid" },
-                "userId": { "$ref": "#/definitions/userId" },
+                "userId": { "$ref": "../../definitions/userId.json" },
                 "name": { "type": "string" },
                 "password": { "type": "string" }
             },
@@ -147,6 +149,8 @@ export interface AutohostAddPlayerRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/addPlayer/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostAddPlayerResponse",
     "tachyon": {
         "source": "autohost",
@@ -235,6 +239,8 @@ Return success instantly and autohost triggers the installation of the engine in
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/installEngine/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostInstallEngineRequest",
     "tachyon": {
         "source": "server",
@@ -299,6 +305,8 @@ export interface AutohostInstallEngineRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/installEngine/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostInstallEngineResponse",
     "tachyon": {
         "source": "autohost",
@@ -385,6 +393,8 @@ Kick a player from a battle.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/kickPlayer/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostKickPlayerRequest",
     "tachyon": {
         "source": "server",
@@ -401,7 +411,7 @@ Kick a player from a battle.
             "type": "object",
             "properties": {
                 "battleId": { "type": "string", "format": "uuid" },
-                "userId": { "$ref": "#/definitions/userId" }
+                "userId": { "$ref": "../../definitions/userId.json" }
             },
             "required": ["battleId", "userId"]
         }
@@ -450,6 +460,8 @@ export interface AutohostKickPlayerRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/kickPlayer/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostKickPlayerResponse",
     "tachyon": {
         "source": "autohost",
@@ -536,6 +548,8 @@ Request to kill a battle.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/kill/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostKillRequest",
     "tachyon": {
         "source": "server",
@@ -596,6 +610,8 @@ export interface AutohostKillRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/kill/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostKillResponse",
     "tachyon": {
         "source": "autohost",
@@ -682,6 +698,8 @@ Mute a player in a battle.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/mutePlayer/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostMutePlayerRequest",
     "tachyon": {
         "source": "server",
@@ -698,7 +716,7 @@ Mute a player in a battle.
             "type": "object",
             "properties": {
                 "battleId": { "type": "string", "format": "uuid" },
-                "userId": { "$ref": "#/definitions/userId" },
+                "userId": { "$ref": "../../definitions/userId.json" },
                 "chat": { "type": "boolean" },
                 "draw": { "type": "boolean" }
             },
@@ -753,6 +771,8 @@ export interface AutohostMutePlayerRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/mutePlayer/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostMutePlayerResponse",
     "tachyon": {
         "source": "autohost",
@@ -839,6 +859,8 @@ Send a custom command for the autohost to execute.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/sendCommand/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostSendCommandRequest",
     "tachyon": {
         "source": "server",
@@ -907,6 +929,8 @@ export interface AutohostSendCommandRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/sendCommand/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostSendCommandResponse",
     "tachyon": {
         "source": "autohost",
@@ -993,6 +1017,8 @@ Send a message for the autohost to display to players.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/sendMessage/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostSendMessageRequest",
     "tachyon": {
         "source": "server",
@@ -1056,6 +1082,8 @@ export interface AutohostSendMessageRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/sendMessage/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostSendMessageResponse",
     "tachyon": {
         "source": "autohost",
@@ -1142,6 +1170,8 @@ Force players to become spectators in a battle.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/specPlayers/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostSpecPlayersRequest",
     "tachyon": {
         "source": "server",
@@ -1160,7 +1190,7 @@ Force players to become spectators in a battle.
                 "battleId": { "type": "string", "format": "uuid" },
                 "userIds": {
                     "type": "array",
-                    "items": { "$ref": "#/definitions/userId" }
+                    "items": { "$ref": "../../definitions/userId.json" }
                 }
             },
             "required": ["battleId", "userIds"]
@@ -1215,6 +1245,8 @@ export interface AutohostSpecPlayersRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/specPlayers/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostSpecPlayersResponse",
     "tachyon": {
         "source": "autohost",
@@ -1301,6 +1333,8 @@ Tell the autohost client to launch the game server (spring-dedicated.exe or spri
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/start/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostStartRequest",
     "tachyon": {
         "source": "server",
@@ -1332,15 +1366,17 @@ Tell the autohost client to launch the game server (spring-dedicated.exe or spri
                     "pattern": "^[a-fA-F0-9]{128}$"
                 },
                 "startDelay": { "type": "integer" },
-                "startPosType": { "$ref": "#/definitions/startPosType" },
+                "startPosType": {
+                    "$ref": "../../definitions/startPosType.json"
+                },
                 "allyTeams": {
                     "type": "array",
-                    "items": { "$ref": "#/definitions/allyTeam" },
+                    "items": { "$ref": "../../definitions/allyTeam.json" },
                     "minItems": 1
                 },
                 "spectators": {
                     "type": "array",
-                    "items": { "$ref": "#/definitions/player" }
+                    "items": { "$ref": "../../definitions/player.json" }
                 },
                 "mapOptions": {
                     "type": "object",
@@ -2170,6 +2206,8 @@ export interface StartBox {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/start/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostStartResponse",
     "tachyon": {
         "source": "autohost",
@@ -2292,6 +2330,8 @@ This event should be sent to the server on connection and whenever any of the st
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/status/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostStatusEvent",
     "tachyon": {
         "source": "autohost",
@@ -2386,6 +2426,8 @@ Ask the autohost to send us updates about its battles. Autohost will send all up
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/subscribeUpdates/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostSubscribeUpdatesRequest",
     "tachyon": {
         "source": "server",
@@ -2400,7 +2442,9 @@ Ask the autohost to send us updates about its battles. Autohost will send all up
         "data": {
             "title": "AutohostSubscribeUpdatesRequestData",
             "type": "object",
-            "properties": { "since": { "$ref": "#/definitions/unixTime" } },
+            "properties": {
+                "since": { "$ref": "../../definitions/unixTime.json" }
+            },
             "required": ["since"]
         }
     },
@@ -2446,6 +2490,8 @@ export interface AutohostSubscribeUpdatesRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/subscribeUpdates/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostSubscribeUpdatesResponse",
     "tachyon": {
         "source": "autohost",
@@ -2532,6 +2578,8 @@ Inform the server of battle updates.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/update/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AutohostUpdateEvent",
     "tachyon": {
         "source": "autohost",
@@ -2548,7 +2596,7 @@ Inform the server of battle updates.
             "type": "object",
             "properties": {
                 "battleId": { "type": "string", "format": "uuid" },
-                "time": { "$ref": "#/definitions/unixTime" },
+                "time": { "$ref": "../../definitions/unixTime.json" },
                 "update": {
                     "anyOf": [
                         {
@@ -2564,7 +2612,9 @@ Inform the server of battle updates.
                             "type": "object",
                             "properties": {
                                 "type": { "const": "finished" },
-                                "userId": { "$ref": "#/definitions/userId" },
+                                "userId": {
+                                    "$ref": "../../definitions/userId.json"
+                                },
                                 "winningAllyTeams": {
                                     "description": "Ally team IDs",
                                     "type": "array",
@@ -2621,7 +2671,9 @@ Inform the server of battle updates.
                             "type": "object",
                             "properties": {
                                 "type": { "const": "player_joined" },
-                                "userId": { "$ref": "#/definitions/userId" },
+                                "userId": {
+                                    "$ref": "../../definitions/userId.json"
+                                },
                                 "playerNumber": {
                                     "description": "Player number in the game, can be useful for custom commands",
                                     "type": "integer"
@@ -2634,7 +2686,9 @@ Inform the server of battle updates.
                             "type": "object",
                             "properties": {
                                 "type": { "const": "player_left" },
-                                "userId": { "$ref": "#/definitions/userId" },
+                                "userId": {
+                                    "$ref": "../../definitions/userId.json"
+                                },
                                 "reason": {
                                     "enum": [
                                         "lost_connection",
@@ -2653,7 +2707,7 @@ Inform the server of battle updates.
                                     "properties": {
                                         "type": { "const": "player_chat" },
                                         "userId": {
-                                            "$ref": "#/definitions/userId"
+                                            "$ref": "../../definitions/userId.json"
                                         },
                                         "message": { "type": "string" },
                                         "destination": {
@@ -2676,12 +2730,12 @@ Inform the server of battle updates.
                                     "properties": {
                                         "type": { "const": "player_chat" },
                                         "userId": {
-                                            "$ref": "#/definitions/userId"
+                                            "$ref": "../../definitions/userId.json"
                                         },
                                         "message": { "type": "string" },
                                         "destination": { "const": "player" },
                                         "toUserId": {
-                                            "$ref": "#/definitions/userId"
+                                            "$ref": "../../definitions/userId.json"
                                         }
                                     },
                                     "required": [
@@ -2699,7 +2753,9 @@ Inform the server of battle updates.
                             "type": "object",
                             "properties": {
                                 "type": { "const": "player_defeated" },
-                                "userId": { "$ref": "#/definitions/userId" }
+                                "userId": {
+                                    "$ref": "../../definitions/userId.json"
+                                }
                             },
                             "required": ["type", "userId"]
                         },
@@ -2709,7 +2765,9 @@ Inform the server of battle updates.
                             "type": "object",
                             "properties": {
                                 "type": { "const": "luamsg" },
-                                "userId": { "$ref": "#/definitions/userId" },
+                                "userId": {
+                                    "$ref": "../../definitions/userId.json"
+                                },
                                 "script": { "enum": ["ui", "game", "rules"] },
                                 "uiMode": {
                                     "description": "Set when script is 'ui'",

--- a/docs/schema/battle.md
+++ b/docs/schema/battle.md
@@ -21,6 +21,8 @@ When a user client receives this response it should launch the game (spring.exe)
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/battle/start/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "BattleStartRequest",
     "tachyon": {
         "source": "server",
@@ -33,7 +35,7 @@ When a user client receives this response it should launch the game (spring.exe)
         "messageId": { "type": "string" },
         "commandId": { "const": "battle/start" },
         "data": {
-            "$ref": "#/definitions/privateBattle",
+            "$ref": "../../definitions/privateBattle.json",
             "title": "BattleStartRequestData"
         }
     },
@@ -101,6 +103,8 @@ export interface BattleStartRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/battle/start/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "BattleStartResponse",
     "tachyon": {
         "source": "user",

--- a/docs/schema/friend.md
+++ b/docs/schema/friend.md
@@ -42,6 +42,8 @@ Accept an incoming friend request
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/acceptRequest/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "FriendAcceptRequestRequest",
     "tachyon": {
         "source": "user",
@@ -56,7 +58,9 @@ Accept an incoming friend request
         "data": {
             "title": "FriendAcceptRequestRequestData",
             "type": "object",
-            "properties": { "from": { "$ref": "#/definitions/userId" } },
+            "properties": {
+                "from": { "$ref": "../../definitions/userId.json" }
+            },
             "required": ["from"]
         }
     },
@@ -102,6 +106,8 @@ export interface FriendAcceptRequestRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/acceptRequest/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "FriendAcceptRequestResponse",
     "tachyon": {
         "source": "server",
@@ -190,6 +196,8 @@ Cancel an invite sent to someone
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/cancelRequest/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "FriendCancelRequestRequest",
     "tachyon": {
         "source": "user",
@@ -204,7 +212,7 @@ Cancel an invite sent to someone
         "data": {
             "title": "FriendCancelRequestRequestData",
             "type": "object",
-            "properties": { "to": { "$ref": "#/definitions/userId" } },
+            "properties": { "to": { "$ref": "../../definitions/userId.json" } },
             "required": ["to"]
         }
     },
@@ -250,6 +258,8 @@ export interface FriendCancelRequestRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/cancelRequest/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "FriendCancelRequestResponse",
     "tachyon": {
         "source": "server",
@@ -337,6 +347,8 @@ Retrieve the status of your friendlist
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/list/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "FriendListRequest",
     "tachyon": {
         "source": "user",
@@ -382,6 +394,8 @@ export interface FriendListRequest {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/list/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "FriendListResponse",
     "tachyon": {
         "source": "server",
@@ -407,10 +421,10 @@ export interface FriendListRequest {
                                 "type": "object",
                                 "properties": {
                                     "userId": {
-                                        "$ref": "#/definitions/userId"
+                                        "$ref": "../../definitions/userId.json"
                                     },
                                     "addedAt": {
-                                        "$ref": "#/definitions/unixTime"
+                                        "$ref": "../../definitions/unixTime.json"
                                     }
                                 },
                                 "required": ["userId", "addedAt"]
@@ -421,9 +435,11 @@ export interface FriendListRequest {
                             "items": {
                                 "type": "object",
                                 "properties": {
-                                    "to": { "$ref": "#/definitions/userId" },
+                                    "to": {
+                                        "$ref": "../../definitions/userId.json"
+                                    },
                                     "sentAt": {
-                                        "$ref": "#/definitions/unixTime"
+                                        "$ref": "../../definitions/unixTime.json"
                                     }
                                 },
                                 "required": ["to", "sentAt"]
@@ -434,9 +450,11 @@ export interface FriendListRequest {
                             "items": {
                                 "type": "object",
                                 "properties": {
-                                    "from": { "$ref": "#/definitions/userId" },
+                                    "from": {
+                                        "$ref": "../../definitions/userId.json"
+                                    },
                                     "sentAt": {
-                                        "$ref": "#/definitions/unixTime"
+                                        "$ref": "../../definitions/unixTime.json"
                                     }
                                 },
                                 "required": ["from", "sentAt"]
@@ -578,6 +596,8 @@ Reject a friend request
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/rejectRequest/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "FriendRejectRequestRequest",
     "tachyon": {
         "source": "user",
@@ -592,7 +612,9 @@ Reject a friend request
         "data": {
             "title": "FriendRejectRequestRequestData",
             "type": "object",
-            "properties": { "from": { "$ref": "#/definitions/userId" } },
+            "properties": {
+                "from": { "$ref": "../../definitions/userId.json" }
+            },
             "required": ["from"]
         }
     },
@@ -638,6 +660,8 @@ export interface FriendRejectRequestRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/rejectRequest/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "FriendRejectRequestResponse",
     "tachyon": {
         "source": "server",
@@ -726,6 +750,8 @@ Remove a player from your friendlist
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/remove/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "FriendRemoveRequest",
     "tachyon": {
         "source": "user",
@@ -740,7 +766,9 @@ Remove a player from your friendlist
         "data": {
             "title": "FriendRemoveRequestData",
             "type": "object",
-            "properties": { "userId": { "$ref": "#/definitions/userId" } },
+            "properties": {
+                "userId": { "$ref": "../../definitions/userId.json" }
+            },
             "required": ["userId"]
         }
     },
@@ -786,6 +814,8 @@ export interface FriendRemoveRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/remove/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "FriendRemoveResponse",
     "tachyon": {
         "source": "server",
@@ -874,6 +904,8 @@ Notify the player that they are no longer friend with a player. Typically, that 
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/removed/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "FriendRemovedEvent",
     "tachyon": {
         "source": "server",
@@ -888,7 +920,9 @@ Notify the player that they are no longer friend with a player. Typically, that 
         "data": {
             "title": "FriendRemovedEventData",
             "type": "object",
-            "properties": { "from": { "$ref": "#/definitions/userId" } },
+            "properties": {
+                "from": { "$ref": "../../definitions/userId.json" }
+            },
             "required": ["from"]
         }
     },
@@ -945,6 +979,8 @@ Notify the player that their friend request has been accepted
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/requestAccepted/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "FriendRequestAcceptedEvent",
     "tachyon": {
         "source": "server",
@@ -959,7 +995,9 @@ Notify the player that their friend request has been accepted
         "data": {
             "title": "FriendRequestAcceptedEventData",
             "type": "object",
-            "properties": { "from": { "$ref": "#/definitions/userId" } },
+            "properties": {
+                "from": { "$ref": "../../definitions/userId.json" }
+            },
             "required": ["from"]
         }
     },
@@ -1016,6 +1054,8 @@ Notify the player that a friend request they received is no longer valid
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/requestCancelled/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "FriendRequestCancelledEvent",
     "tachyon": {
         "source": "server",
@@ -1030,7 +1070,9 @@ Notify the player that a friend request they received is no longer valid
         "data": {
             "title": "FriendRequestCancelledEventData",
             "type": "object",
-            "properties": { "from": { "$ref": "#/definitions/userId" } },
+            "properties": {
+                "from": { "$ref": "../../definitions/userId.json" }
+            },
             "required": ["from"]
         }
     },
@@ -1087,6 +1129,8 @@ Notify the player that someone sent them a friend request
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/requestReceived/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "FriendRequestReceivedEvent",
     "tachyon": {
         "source": "server",
@@ -1101,7 +1145,9 @@ Notify the player that someone sent them a friend request
         "data": {
             "title": "FriendRequestReceivedEventData",
             "type": "object",
-            "properties": { "from": { "$ref": "#/definitions/userId" } },
+            "properties": {
+                "from": { "$ref": "../../definitions/userId.json" }
+            },
             "required": ["from"]
         }
     },
@@ -1158,6 +1204,8 @@ Notify the player that their friend request has been rejected
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/requestRejected/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "FriendRequestRejectedEvent",
     "tachyon": {
         "source": "server",
@@ -1172,7 +1220,9 @@ Notify the player that their friend request has been rejected
         "data": {
             "title": "FriendRequestRejectedEventData",
             "type": "object",
-            "properties": { "from": { "$ref": "#/definitions/userId" } },
+            "properties": {
+                "from": { "$ref": "../../definitions/userId.json" }
+            },
             "required": ["from"]
         }
     },
@@ -1229,6 +1279,8 @@ Send a friend request to the target player
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/sendRequest/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "FriendSendRequestRequest",
     "tachyon": {
         "source": "user",
@@ -1243,7 +1295,7 @@ Send a friend request to the target player
         "data": {
             "title": "FriendSendRequestRequestData",
             "type": "object",
-            "properties": { "to": { "$ref": "#/definitions/userId" } },
+            "properties": { "to": { "$ref": "../../definitions/userId.json" } },
             "required": ["to"]
         }
     },
@@ -1289,6 +1341,8 @@ export interface FriendSendRequestRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/sendRequest/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "FriendSendRequestResponse",
     "tachyon": {
         "source": "server",

--- a/docs/schema/lobby.md
+++ b/docs/schema/lobby.md
@@ -163,6 +163,8 @@ Add a bot to the specified ally team
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/addBot/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyAddBotRequest",
     "tachyon": {
         "source": "user",
@@ -252,6 +254,8 @@ export interface LobbyAddBotRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/addBot/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyAddBotResponse",
     "tachyon": {
         "source": "server",
@@ -358,6 +362,8 @@ Create a lobby
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/create/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyCreateRequest",
     "tachyon": {
         "source": "user",
@@ -375,7 +381,9 @@ Create a lobby
             "properties": {
                 "name": { "type": "string" },
                 "mapName": { "type": "string" },
-                "allyTeamConfig": { "$ref": "#/definitions/allyTeamConfig" }
+                "allyTeamConfig": {
+                    "$ref": "../../definitions/allyTeamConfig.json"
+                }
             },
             "required": ["name", "mapName", "allyTeamConfig"]
         }
@@ -476,6 +484,8 @@ export interface StartBox {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/create/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyCreateResponse",
     "tachyon": {
         "source": "server",
@@ -492,7 +502,7 @@ export interface StartBox {
                 "commandId": { "const": "lobby/create" },
                 "status": { "const": "success" },
                 "data": {
-                    "$ref": "#/definitions/lobbyDetails",
+                    "$ref": "../../definitions/lobbyDetails.json",
                     "title": "LobbyCreateOkResponseData"
                 }
             },
@@ -787,6 +797,8 @@ Join a lobby. On success, get the lobby state and will receive updated events as
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/join/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyJoinRequest",
     "tachyon": {
         "source": "user",
@@ -845,6 +857,8 @@ export interface LobbyJoinRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/join/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyJoinResponse",
     "tachyon": {
         "source": "server",
@@ -861,7 +875,7 @@ export interface LobbyJoinRequestData {
                 "commandId": { "const": "lobby/join" },
                 "status": { "const": "success" },
                 "data": {
-                    "$ref": "#/definitions/lobbyDetails",
+                    "$ref": "../../definitions/lobbyDetails.json",
                     "title": "LobbyJoinOkResponseData"
                 }
             },
@@ -1197,6 +1211,8 @@ Joins the given ally team in an empty team.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/joinAllyTeam/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyJoinAllyTeamRequest",
     "tachyon": {
         "source": "user",
@@ -1255,6 +1271,8 @@ export interface LobbyJoinAllyTeamRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/joinAllyTeam/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyJoinAllyTeamResponse",
     "tachyon": {
         "source": "server",
@@ -1343,6 +1361,8 @@ Joins the waiting queue to play. The server will automatically put the user in t
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/joinQueue/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyJoinQueueRequest",
     "tachyon": {
         "source": "user",
@@ -1388,6 +1408,8 @@ export interface LobbyJoinQueueRequest {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/joinQueue/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyJoinQueueResponse",
     "tachyon": {
         "source": "server",
@@ -1475,6 +1497,8 @@ Leave the lobby, also unsubscribe from any update
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/leave/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyLeaveRequest",
     "tachyon": {
         "source": "user",
@@ -1520,6 +1544,8 @@ export interface LobbyLeaveRequest {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/leave/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyLeaveResponse",
     "tachyon": {
         "source": "server",
@@ -1606,6 +1632,8 @@ Sent by the server when the player is removed from the lobby. Can be kicked/ban 
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/left/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyLeftEvent",
     "tachyon": {
         "source": "server",
@@ -1680,6 +1708,8 @@ Sent by the server to give the client the full list of all lobbies
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/listReset/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyListResetEvent",
     "tachyon": {
         "source": "server",
@@ -1698,7 +1728,9 @@ Sent by the server to give the client the full list of all lobbies
                 "lobbies": {
                     "type": "object",
                     "patternProperties": {
-                        "^(.*)$": { "$ref": "#/definitions/lobbyOverview" }
+                        "^(.*)$": {
+                            "$ref": "../../definitions/lobbyOverview.json"
+                        }
                     }
                 }
             },
@@ -1783,6 +1815,8 @@ Sent by the server whenever some lobbies are added, removed or modified.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/listUpdated/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyListUpdatedEvent",
     "tachyon": {
         "source": "server",
@@ -1819,7 +1853,7 @@ Sent by the server whenever some lobbies are added, removed or modified.
                                                     "type": "object",
                                                     "properties": {
                                                         "startedAt": {
-                                                            "$ref": "#/definitions/unixTime"
+                                                            "$ref": "../../definitions/unixTime.json"
                                                         }
                                                     },
                                                     "required": ["startedAt"]
@@ -1919,6 +1953,8 @@ Remove the specified bot from the lobby
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/removeBot/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyRemoveBotRequest",
     "tachyon": {
         "source": "user",
@@ -1977,6 +2013,8 @@ export interface LobbyRemoveBotRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/removeBot/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyRemoveBotResponse",
     "tachyon": {
         "source": "server",
@@ -2065,6 +2103,8 @@ Move the client to the spectator queue. If already in spectator queue, has no ef
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/spectate/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbySpectateRequest",
     "tachyon": {
         "source": "user",
@@ -2110,6 +2150,8 @@ export interface LobbySpectateRequest {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/spectate/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbySpectateResponse",
     "tachyon": {
         "source": "server",
@@ -2197,6 +2239,8 @@ Start the battle for the lobby. If this request succeed players will receive a b
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/startBattle/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyStartBattleRequest",
     "tachyon": {
         "source": "user",
@@ -2242,6 +2286,8 @@ export interface LobbyStartBattleRequest {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/startBattle/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyStartBattleResponse",
     "tachyon": {
         "source": "server",
@@ -2328,6 +2374,8 @@ Ask the server to send updates about lobby list. Idempotent, subscribing multipl
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/subscribeList/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbySubscribeListRequest",
     "tachyon": {
         "source": "user",
@@ -2373,6 +2421,8 @@ export interface LobbySubscribeListRequest {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/subscribeList/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbySubscribeListResponse",
     "tachyon": {
         "source": "server",
@@ -2459,6 +2509,8 @@ Ask the server to stop sending updates about lobby list. Idempotent, if not subs
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/unsubscribeList/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyUnsubscribeListRequest",
     "tachyon": {
         "source": "user",
@@ -2504,6 +2556,8 @@ export interface LobbyUnsubscribeListRequest {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/unsubscribeList/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyUnsubscribeListResponse",
     "tachyon": {
         "source": "server",
@@ -2590,6 +2644,8 @@ Update some properties of the lobby the player is in.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/update/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyUpdateRequest",
     "tachyon": {
         "source": "user",
@@ -2610,7 +2666,9 @@ Update some properties of the lobby the player is in.
                     "type": "string"
                 },
                 "mapName": { "type": "string" },
-                "allyTeamConfig": { "$ref": "#/definitions/allyTeamConfig" }
+                "allyTeamConfig": {
+                    "$ref": "../../definitions/allyTeamConfig.json"
+                }
             }
         }
     },
@@ -2718,6 +2776,8 @@ export interface StartBox {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/update/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyUpdateResponse",
     "tachyon": {
         "source": "server",
@@ -2804,6 +2864,8 @@ Change a bot properties. Some properties like ID and allyTeam can't be changed.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/updateBot/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyUpdateBotRequest",
     "tachyon": {
         "source": "user",
@@ -2899,6 +2961,8 @@ export interface LobbyUpdateBotRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/updateBot/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyUpdateBotResponse",
     "tachyon": {
         "source": "server",
@@ -2987,6 +3051,8 @@ Update the player's status
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/updateClientStatus/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyUpdateClientStatusRequest",
     "tachyon": {
         "source": "user",
@@ -3049,6 +3115,8 @@ export interface LobbyUpdateClientStatusRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/updateClientStatus/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyUpdateClientStatusResponse",
     "tachyon": {
         "source": "server",
@@ -3137,6 +3205,8 @@ Sent by the server whenever something in the lobby changes. Uses json patch (RFC
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/updated/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyUpdatedEvent",
     "tachyon": {
         "source": "server",
@@ -3167,7 +3237,7 @@ Sent by the server whenever something in the lobby changes. Uses json patch (RFC
                                     "type": "object",
                                     "properties": {
                                         "startBox": {
-                                            "$ref": "#/definitions/startBox"
+                                            "$ref": "../../definitions/startBox.json"
                                         },
                                         "maxTeams": {
                                             "type": "integer",
@@ -3209,7 +3279,7 @@ Sent by the server whenever something in the lobby changes. Uses json patch (RFC
                                     "type": "object",
                                     "properties": {
                                         "id": {
-                                            "$ref": "#/definitions/userId"
+                                            "$ref": "../../definitions/userId.json"
                                         },
                                         "allyTeam": { "type": "string" },
                                         "team": { "type": "string" },
@@ -3239,7 +3309,7 @@ Sent by the server whenever something in the lobby changes. Uses json patch (RFC
                                     "type": "object",
                                     "properties": {
                                         "id": {
-                                            "$ref": "#/definitions/userId"
+                                            "$ref": "../../definitions/userId.json"
                                         },
                                         "joinQueuePosition": {
                                             "anyOf": [
@@ -3265,7 +3335,7 @@ Sent by the server whenever something in the lobby changes. Uses json patch (RFC
                                     "properties": {
                                         "id": { "type": "string" },
                                         "hostUserId": {
-                                            "$ref": "#/definitions/userId"
+                                            "$ref": "../../definitions/userId.json"
                                         },
                                         "allyTeam": { "type": "string" },
                                         "team": { "type": "string" },
@@ -3325,7 +3395,7 @@ Sent by the server whenever something in the lobby changes. Uses json patch (RFC
                             "properties": {
                                 "id": { "type": "string" },
                                 "startedAt": {
-                                    "$ref": "#/definitions/unixTime"
+                                    "$ref": "../../definitions/unixTime.json"
                                 }
                             },
                             "required": ["id", "startedAt"]
@@ -3341,11 +3411,15 @@ Sent by the server whenever something in the lobby changes. Uses json patch (RFC
                                 "id": { "type": "string" },
                                 "action": {
                                     "anyOf": [
-                                        { "$ref": "#/definitions/voteActions" },
+                                        {
+                                            "$ref": "../../definitions/voteActions.json"
+                                        },
                                         { "type": "null" }
                                     ]
                                 },
-                                "initiator": { "$ref": "#/definitions/userId" },
+                                "initiator": {
+                                    "$ref": "../../definitions/userId.json"
+                                },
                                 "voters": {
                                     "type": "object",
                                     "patternProperties": {
@@ -3365,7 +3439,9 @@ Sent by the server whenever something in the lobby changes. Uses json patch (RFC
                                         }
                                     }
                                 },
-                                "until": { "$ref": "#/definitions/unixTime" }
+                                "until": {
+                                    "$ref": "../../definitions/unixTime.json"
+                                }
                             },
                             "required": ["id"]
                         },
@@ -3570,6 +3646,8 @@ To let clients know a vote has finished and its outcome
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/voteEnded/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyVoteEndedEvent",
     "tachyon": {
         "source": "server",
@@ -3644,6 +3722,8 @@ export interface LobbyVoteEndedEventData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/voteSubmit/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyVoteSubmitRequest",
     "tachyon": {
         "source": "user",
@@ -3707,6 +3787,8 @@ export interface LobbyVoteSubmitRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/voteSubmit/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "LobbyVoteSubmitResponse",
     "tachyon": {
         "source": "server",

--- a/docs/schema/matchmaking.md
+++ b/docs/schema/matchmaking.md
@@ -56,6 +56,8 @@ Cancel queueing for matchmaking.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/cancel/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MatchmakingCancelRequest",
     "tachyon": {
         "source": "user",
@@ -101,6 +103,8 @@ export interface MatchmakingCancelRequest {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/cancel/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MatchmakingCancelResponse",
     "tachyon": {
         "source": "server",
@@ -188,6 +192,8 @@ Server may send this event at any point when the user is queuing to indicate tha
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/cancelled/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MatchmakingCancelledEvent",
     "tachyon": {
         "source": "server",
@@ -267,6 +273,8 @@ Server should send this when there are enough queued players to form a valid bat
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/found/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MatchmakingFoundEvent",
     "tachyon": {
         "source": "server",
@@ -341,6 +349,8 @@ Server should send this when players ready up using [ready](#ready).
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/foundUpdate/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MatchmakingFoundUpdateEvent",
     "tachyon": {
         "source": "server",
@@ -410,6 +420,8 @@ Returns all available matchmaking playlists.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/list/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MatchmakingListRequest",
     "tachyon": {
         "source": "user",
@@ -455,6 +467,8 @@ export interface MatchmakingListRequest {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/list/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MatchmakingListResponse",
     "tachyon": {
         "source": "server",
@@ -728,6 +742,8 @@ Sent when a found match gets disbanded because a client failed to ready up.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/lost/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MatchmakingLostEvent",
     "tachyon": {
         "source": "server",
@@ -784,6 +800,8 @@ Queue up for matchmaking. Should cancel the previous queue if already in one.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/queue/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MatchmakingQueueRequest",
     "tachyon": {
         "source": "user",
@@ -879,6 +897,8 @@ export interface MatchmakingQueueRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/queue/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MatchmakingQueueResponse",
     "tachyon": {
         "source": "server",
@@ -969,6 +989,8 @@ Contains some info about the state of the current queue.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/queueUpdate/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MatchmakingQueueUpdateEvent",
     "tachyon": {
         "source": "server",
@@ -1038,6 +1060,8 @@ Indicate the player has been added to some queues by someone else. This happens 
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/queuesJoined/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MatchmakingQueuesJoinedEvent",
     "tachyon": {
         "source": "server",
@@ -1119,6 +1143,8 @@ Clients should send this when they are ready to proceed with the found match. If
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/ready/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MatchmakingReadyRequest",
     "tachyon": {
         "source": "user",
@@ -1164,6 +1190,8 @@ export interface MatchmakingReadyRequest {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/ready/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MatchmakingReadyResponse",
     "tachyon": {
         "source": "server",

--- a/docs/schema/messaging.md
+++ b/docs/schema/messaging.md
@@ -55,6 +55,8 @@ Notify the player a message has been received
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/messaging/received/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MessagingReceivedEvent",
     "tachyon": {
         "source": "server",
@@ -77,7 +79,9 @@ Notify the player a message has been received
                             "type": "object",
                             "properties": {
                                 "type": { "const": "player" },
-                                "userId": { "$ref": "#/definitions/userId" }
+                                "userId": {
+                                    "$ref": "../../definitions/userId.json"
+                                }
                             },
                             "required": ["type", "userId"]
                         },
@@ -85,18 +89,22 @@ Notify the player a message has been received
                             "type": "object",
                             "properties": {
                                 "type": { "const": "party" },
-                                "partyId": { "$ref": "#/definitions/partyId" },
-                                "userId": { "$ref": "#/definitions/userId" }
+                                "partyId": {
+                                    "$ref": "../../definitions/partyId.json"
+                                },
+                                "userId": {
+                                    "$ref": "../../definitions/userId.json"
+                                }
                             },
                             "required": ["type", "partyId", "userId"]
                         }
                     ]
                 },
                 "timestamp": {
-                    "$ref": "#/definitions/unixTime",
+                    "$ref": "../../definitions/unixTime.json",
                     "description": "time at which the message was received by the server"
                 },
-                "marker": { "$ref": "#/definitions/historyMarker" }
+                "marker": { "$ref": "../../definitions/historyMarker.json" }
             },
             "required": ["message", "source", "timestamp", "marker"]
         }
@@ -174,6 +182,8 @@ Send a simple message to the given target.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/messaging/send/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MessagingSendRequest",
     "tachyon": {
         "source": "user",
@@ -195,7 +205,9 @@ Send a simple message to the given target.
                             "type": "object",
                             "properties": {
                                 "type": { "const": "player" },
-                                "userId": { "$ref": "#/definitions/userId" }
+                                "userId": {
+                                    "$ref": "../../definitions/userId.json"
+                                }
                             },
                             "required": ["type", "userId"]
                         },
@@ -264,6 +276,8 @@ export interface MessagingSendRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/messaging/send/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MessagingSendResponse",
     "tachyon": {
         "source": "server",
@@ -352,6 +366,8 @@ Ask the server to send events for relevant messages
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/messaging/subscribeReceived/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MessagingSubscribeReceivedRequest",
     "tachyon": {
         "source": "user",
@@ -384,7 +400,7 @@ Ask the server to send events for relevant messages
                             "properties": {
                                 "type": { "const": "marker" },
                                 "value": {
-                                    "$ref": "#/definitions/historyMarker"
+                                    "$ref": "../../definitions/historyMarker.json"
                                 }
                             },
                             "required": ["type", "value"]
@@ -448,6 +464,8 @@ export interface MessagingSubscribeReceivedRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/messaging/subscribeReceived/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MessagingSubscribeReceivedResponse",
     "tachyon": {
         "source": "server",

--- a/docs/schema/party.md
+++ b/docs/schema/party.md
@@ -64,6 +64,8 @@ Accept the invite to the party
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/acceptInvite/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "PartyAcceptInviteRequest",
     "tachyon": {
         "source": "user",
@@ -78,7 +80,9 @@ Accept the invite to the party
         "data": {
             "title": "PartyAcceptInviteRequestData",
             "type": "object",
-            "properties": { "partyId": { "$ref": "#/definitions/partyId" } },
+            "properties": {
+                "partyId": { "$ref": "../../definitions/partyId.json" }
+            },
             "required": ["partyId"]
         }
     },
@@ -124,6 +128,8 @@ export interface PartyAcceptInviteRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/acceptInvite/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "PartyAcceptInviteResponse",
     "tachyon": {
         "source": "server",
@@ -210,6 +216,8 @@ cancel a pending invite for the given player
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/cancelInvite/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "PartyCancelInviteRequest",
     "tachyon": {
         "source": "user",
@@ -224,7 +232,9 @@ cancel a pending invite for the given player
         "data": {
             "title": "PartyCancelInviteRequestData",
             "type": "object",
-            "properties": { "userId": { "$ref": "#/definitions/userId" } },
+            "properties": {
+                "userId": { "$ref": "../../definitions/userId.json" }
+            },
             "required": ["userId"]
         }
     },
@@ -270,6 +280,8 @@ export interface PartyCancelInviteRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/cancelInvite/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "PartyCancelInviteResponse",
     "tachyon": {
         "source": "server",
@@ -358,6 +370,8 @@ Create a party.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/create/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "PartyCreateRequest",
     "tachyon": {
         "source": "user",
@@ -403,6 +417,8 @@ export interface PartyCreateRequest {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/create/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "PartyCreateResponse",
     "tachyon": {
         "source": "server",
@@ -422,7 +438,7 @@ export interface PartyCreateRequest {
                     "title": "PartyCreateOkResponseData",
                     "type": "object",
                     "properties": {
-                        "partyId": { "$ref": "#/definitions/partyId" }
+                        "partyId": { "$ref": "../../definitions/partyId.json" }
                     },
                     "required": ["partyId"]
                 }
@@ -506,6 +522,8 @@ Decline the invite to a party
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/declineInvite/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "PartyDeclineInviteRequest",
     "tachyon": {
         "source": "user",
@@ -520,7 +538,9 @@ Decline the invite to a party
         "data": {
             "title": "PartyDeclineInviteRequestData",
             "type": "object",
-            "properties": { "partyId": { "$ref": "#/definitions/partyId" } },
+            "properties": {
+                "partyId": { "$ref": "../../definitions/partyId.json" }
+            },
             "required": ["partyId"]
         }
     },
@@ -566,6 +586,8 @@ export interface PartyDeclineInviteRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/declineInvite/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "PartyDeclineInviteResponse",
     "tachyon": {
         "source": "server",
@@ -652,6 +674,8 @@ invite the target player to your current party
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/invite/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "PartyInviteRequest",
     "tachyon": {
         "source": "user",
@@ -666,7 +690,9 @@ invite the target player to your current party
         "data": {
             "title": "PartyInviteRequestData",
             "type": "object",
-            "properties": { "userId": { "$ref": "#/definitions/userId" } },
+            "properties": {
+                "userId": { "$ref": "../../definitions/userId.json" }
+            },
             "required": ["userId"]
         }
     },
@@ -712,6 +738,8 @@ export interface PartyInviteRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/invite/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "PartyInviteResponse",
     "tachyon": {
         "source": "server",
@@ -798,6 +826,8 @@ A player has been invited to the party. Sent to the invited player and all party
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/invited/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "PartyInvitedEvent",
     "tachyon": {
         "source": "server",
@@ -812,7 +842,9 @@ A player has been invited to the party. Sent to the invited player and all party
         "data": {
             "title": "PartyInvitedEventData",
             "type": "object",
-            "properties": { "party": { "$ref": "#/definitions/partyState" } },
+            "properties": {
+                "party": { "$ref": "../../definitions/partyState.json" }
+            },
             "required": ["party"]
         }
     },
@@ -912,6 +944,8 @@ Kick the target player from the party
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/kickMember/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "PartyKickMemberRequest",
     "tachyon": {
         "source": "user",
@@ -926,7 +960,9 @@ Kick the target player from the party
         "data": {
             "title": "PartyKickMemberRequestData",
             "type": "object",
-            "properties": { "userId": { "$ref": "#/definitions/userId" } },
+            "properties": {
+                "userId": { "$ref": "../../definitions/userId.json" }
+            },
             "required": ["userId"]
         }
     },
@@ -972,6 +1008,8 @@ export interface PartyKickMemberRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/kickMember/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "PartyKickMemberResponse",
     "tachyon": {
         "source": "server",
@@ -1058,6 +1096,8 @@ Leave the party
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/leave/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "PartyLeaveRequest",
     "tachyon": {
         "source": "user",
@@ -1103,6 +1143,8 @@ export interface PartyLeaveRequest {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/leave/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "PartyLeaveResponse",
     "tachyon": {
         "source": "server",
@@ -1189,6 +1231,8 @@ Client has been removed from the party. Either kicked, the invite was cancelled 
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/removed/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "PartyRemovedEvent",
     "tachyon": {
         "source": "server",
@@ -1203,7 +1247,9 @@ Client has been removed from the party. Either kicked, the invite was cancelled 
         "data": {
             "title": "PartyRemovedEventData",
             "type": "object",
-            "properties": { "partyId": { "$ref": "#/definitions/partyId" } },
+            "properties": {
+                "partyId": { "$ref": "../../definitions/partyId.json" }
+            },
             "required": ["partyId"]
         }
     },
@@ -1260,6 +1306,8 @@ New player joined the party (accepted an invite)
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/updated/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "PartyUpdatedEvent",
     "tachyon": {
         "source": "server",
@@ -1272,7 +1320,7 @@ New player joined the party (accepted an invite)
         "messageId": { "type": "string" },
         "commandId": { "const": "party/updated" },
         "data": {
-            "$ref": "#/definitions/partyState",
+            "$ref": "../../definitions/partyState.json",
             "title": "PartyUpdatedEventData"
         }
     },

--- a/docs/schema/system.md
+++ b/docs/schema/system.md
@@ -22,6 +22,8 @@ Ask the server to terminate the connection.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/system/disconnect/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "SystemDisconnectRequest",
     "tachyon": {
         "source": "user",
@@ -40,7 +42,7 @@ Ask the server to terminate the connection.
             "required": ["reason"]
         }
     },
-    "required": ["type", "messageId", "commandId"]
+    "required": ["type", "messageId", "commandId", "data"]
 }
 
 ```
@@ -52,10 +54,10 @@ Ask the server to terminate the connection.
 ```json
 {
     "type": "request",
-    "messageId": "amet aliqua Duis irure tempor",
+    "messageId": "mollit magna dolore",
     "commandId": "system/disconnect",
     "data": {
-        "reason": "laborum consequat irure ullamco"
+        "reason": "dolor non ullamco"
     }
 }
 ```
@@ -67,7 +69,7 @@ export interface SystemDisconnectRequest {
     type: "request";
     messageId: string;
     commandId: "system/disconnect";
-    data?: SystemDisconnectRequestData;
+    data: SystemDisconnectRequestData;
 }
 export interface SystemDisconnectRequestData {
     reason: string;
@@ -80,6 +82,8 @@ export interface SystemDisconnectRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/system/disconnect/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "SystemDisconnectResponse",
     "tachyon": {
         "source": "server",
@@ -166,6 +170,8 @@ Get server stats such as user count.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/system/serverStats/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "SystemServerStatsRequest",
     "tachyon": {
         "source": "user",
@@ -211,6 +217,8 @@ export interface SystemServerStatsRequest {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/system/serverStats/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "SystemServerStatsResponse",
     "tachyon": {
         "source": "server",

--- a/docs/schema/user.md
+++ b/docs/schema/user.md
@@ -25,6 +25,8 @@ Fetch user info from the server.
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/user/info/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "UserInfoRequest",
     "tachyon": {
         "source": "user",
@@ -39,7 +41,9 @@ Fetch user info from the server.
         "data": {
             "title": "UserInfoRequestData",
             "type": "object",
-            "properties": { "userId": { "$ref": "#/definitions/userId" } },
+            "properties": {
+                "userId": { "$ref": "../../definitions/userId.json" }
+            },
             "required": ["userId"]
         }
     },
@@ -85,6 +89,8 @@ export interface UserInfoRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/user/info/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "UserInfoResponse",
     "tachyon": {
         "source": "server",
@@ -101,7 +107,7 @@ export interface UserInfoRequestData {
                 "commandId": { "const": "user/info" },
                 "status": { "const": "success" },
                 "data": {
-                    "$ref": "#/definitions/user",
+                    "$ref": "../../definitions/user.json",
                     "title": "UserInfoOkResponseData"
                 }
             },
@@ -209,6 +215,8 @@ Sent by the server to inform the client of its own user state. This event should
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/user/self/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "UserSelfEvent",
     "tachyon": {
         "source": "server",
@@ -223,7 +231,9 @@ Sent by the server to inform the client of its own user state. This event should
         "data": {
             "title": "UserSelfEventData",
             "type": "object",
-            "properties": { "user": { "$ref": "#/definitions/privateUser" } },
+            "properties": {
+                "user": { "$ref": "../../definitions/privateUser.json" }
+            },
             "required": ["user"]
         }
     },
@@ -421,6 +431,8 @@ Ask the server to send updates about theses users. A maximum of 100 userIds can 
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/user/subscribeUpdates/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "UserSubscribeUpdatesRequest",
     "tachyon": {
         "source": "user",
@@ -438,7 +450,7 @@ Ask the server to send updates about theses users. A maximum of 100 userIds can 
             "properties": {
                 "userIds": {
                     "type": "array",
-                    "items": { "$ref": "#/definitions/userId" },
+                    "items": { "$ref": "../../definitions/userId.json" },
                     "minItems": 1,
                     "maxItems": 100
                 }
@@ -521,6 +533,8 @@ export interface UserSubscribeUpdatesRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/user/subscribeUpdates/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "UserSubscribeUpdatesResponse",
     "tachyon": {
         "source": "server",
@@ -608,6 +622,8 @@ Ask the server to stop sending user updates for the given set of userId. This sh
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/user/unsubscribeUpdates/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "UserUnsubscribeUpdatesRequest",
     "tachyon": {
         "source": "user",
@@ -625,7 +641,7 @@ Ask the server to stop sending user updates for the given set of userId. This sh
             "properties": {
                 "userIds": {
                     "type": "array",
-                    "items": { "$ref": "#/definitions/userId" },
+                    "items": { "$ref": "../../definitions/userId.json" },
                     "minItems": 1,
                     "maxItems": 100
                 }
@@ -692,6 +708,8 @@ export interface UserUnsubscribeUpdatesRequestData {
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/user/unsubscribeUpdates/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "UserUnsubscribeUpdatesResponse",
     "tachyon": {
         "source": "server",
@@ -778,6 +796,8 @@ Sent by the server to inform the client of user state changes. User objects shou
 
 ```json
 {
+    "$id": "https://schema.beyondallreason.dev/tachyon/user/updated/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "UserUpdatedEvent",
     "tachyon": {
         "source": "server",
@@ -798,7 +818,9 @@ Sent by the server to inform the client of user state changes. User objects shou
                     "items": {
                         "type": "object",
                         "properties": {
-                            "userId": { "$ref": "#/definitions/userId" },
+                            "userId": {
+                                "$ref": "../../definitions/userId.json"
+                            },
                             "username": { "type": "string" },
                             "displayName": { "type": "string" },
                             "clanId": {

--- a/schema/compiled.json
+++ b/schema/compiled.json
@@ -5204,7 +5204,7 @@
                     "required": ["reason"]
                 }
             },
-            "required": ["type", "messageId", "commandId"]
+            "required": ["type", "messageId", "commandId", "data"]
         },
         {
             "title": "SystemDisconnectResponse",

--- a/schema/system/disconnect/request.json
+++ b/schema/system/disconnect/request.json
@@ -19,5 +19,5 @@
             "required": ["reason"]
         }
     },
-    "required": ["type", "messageId", "commandId"]
+    "required": ["type", "messageId", "commandId", "data"]
 }

--- a/src/generate-json-schemas.ts
+++ b/src/generate-json-schemas.ts
@@ -118,7 +118,7 @@ export async function generateJsonSchemas(): Promise<TachyonConfig> {
                     commandId: Type.Literal(commandId),
                 };
                 if (schemaConfig.request.data) {
-                    props.data = schemaConfig.request.data;
+                    props.data = structuredClone(schemaConfig.request.data);
                     props.data.title ??= baseTypeName + "RequestData";
                 }
                 const requestSchema = Type.Object(props, {
@@ -174,7 +174,7 @@ export async function generateJsonSchemas(): Promise<TachyonConfig> {
                             };
                             const title = schema.title ?? baseTypeName + "OkResponse";
                             if (schema.data) {
-                                props.data = schema.data;
+                                props.data = structuredClone(schema.data);
                                 props.data.title ??= title + "Data";
                             }
                             return Type.Object(props, { title });
@@ -225,7 +225,7 @@ export async function generateJsonSchemas(): Promise<TachyonConfig> {
                     commandId: Type.Literal(commandId),
                 };
                 if (schemaConfig.event.data) {
-                    props.data = schemaConfig.event.data;
+                    props.data = structuredClone(schemaConfig.event.data);
                     props.data.title ??= baseTypeName + "EventData";
                 }
                 const eventSchema = Type.Object(props, {
@@ -312,7 +312,7 @@ export async function generateJsonSchemas(): Promise<TachyonConfig> {
     const individualSchemas: TSchema[] = [];
 
     objectKeys(commandConfigs).forEach((commandId) => {
-        const commandConfig = commandConfigs[commandId];
+        const commandConfig = structuredClone(commandConfigs[commandId]);
         const [serviceId, endpointId] = commandId.split("/") as [string, string];
 
         if (commandConfig.type === "requestResponse") {


### PR DESCRIPTION
When a definition has a ref to another definition, it would produce an invalid path like
`../definitions/../../definitions/clanBaseData.json.json` so detect this case and adjust the logic to get the correct path.

I do not fully understand the whole logic behind all the `mapRefs`, so there may be a better way to achieve the same result, I'm not sure how.