### PR TITLE
Fix of clanId in clan.ts and clanBaseData.ts

### DIFF
--- a/docs/schema/clan.md
+++ b/docs/schema/clan.md
@@ -1987,15 +1987,48 @@ export interface ClanViewRequestData {
     "messageId": "nisi est dolore sit",
     "commandId": "clan/view",
     "status": "success",
-    "data": "12345"
+    "data": {
+        "clanId": "12345",
+        "name": "fugiat tempor",
+        "tag": "paria",
+        "description": "dolor amet et laboris",
+        "members": [
+            {
+                "userId": "351",
+                "role": "leader",
+                "joinedAt": 1705432698000000
+            },
+            {
+                "userId": "351",
+                "role": "leader",
+                "joinedAt": 1705432698000000
+            },
+            {
+                "userId": "351",
+                "role": "coLeader",
+                "joinedAt": 1705432698000000
+            },
+            {
+                "userId": "351",
+                "role": "member",
+                "joinedAt": 1705432698000000
+            },
+            {
+                "userId": "351",
+                "role": "coLeader",
+                "joinedAt": 1705432698000000
+            }
+        ]
+    }
 }
 ```
 </details>
 
 #### TypeScript Definition
 ```ts
-export type ClanViewOkResponseData = ClanId &
-    ClanUpdateableData & {
+export type ClanViewOkResponseData = {
+    clanId: ClanId;
+} & ClanUpdateableData & {
         members: ClanMember[];
     };
 export type ClanId = string;
@@ -2154,10 +2187,26 @@ export interface ClanViewListRequest {
     "status": "success",
     "data": {
         "clanList": [
-            "12345",
-            "12345",
-            "12345",
-            "12345"
+            {
+                "clanId": "12345",
+                "name": "nulla dolor amet",
+                "tag": "sit d"
+            },
+            {
+                "clanId": "12345",
+                "name": "non pariatur dolore",
+                "tag": "temp"
+            },
+            {
+                "clanId": "12345",
+                "name": "cillum occaeca",
+                "tag": "in e"
+            },
+            {
+                "clanId": "12345",
+                "name": "do officia dolo",
+                "tag": "eu id "
+            }
         ]
     }
 }
@@ -2166,7 +2215,9 @@ export interface ClanViewListRequest {
 
 #### TypeScript Definition
 ```ts
-export type ClanBaseData = ClanId & ClanUpdateableBaseData;
+export type ClanBaseData = {
+    clanId: ClanId;
+} & ClanUpdateableBaseData;
 export type ClanId = string;
 
 export interface ClanViewListOkResponse {

--- a/schema/compiled.json
+++ b/schema/compiled.json
@@ -75,7 +75,13 @@
         },
         "clan": {
             "allOf": [
-                { "$ref": "#/definitions/clanId" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "clanId": { "$ref": "#/definitions/clanId" }
+                    },
+                    "required": ["clanId"]
+                },
                 { "$ref": "#/definitions/clanUpdateableData" },
                 {
                     "type": "object",
@@ -91,7 +97,13 @@
         },
         "clanBaseData": {
             "allOf": [
-                { "$ref": "#/definitions/clanId" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "clanId": { "$ref": "#/definitions/clanId" }
+                    },
+                    "required": ["clanId"]
+                },
                 { "$ref": "#/definitions/clanUpdateableBaseData" }
             ]
         },

--- a/schema/definitions/clan.json
+++ b/schema/definitions/clan.json
@@ -2,7 +2,13 @@
     "$id": "https://schema.beyondallreason.dev/tachyon/definitions/clan.json",
     "title": "Clan",
     "allOf": [
-        { "$ref": "../definitions/clanId.json" },
+        {
+            "type": "object",
+            "properties": {
+                "clanId": { "$ref": "../definitions/clanId.json" }
+            },
+            "required": ["clanId"]
+        },
         { "$ref": "../definitions/clanUpdateableData.json" },
         {
             "type": "object",

--- a/schema/definitions/clanBaseData.json
+++ b/schema/definitions/clanBaseData.json
@@ -2,7 +2,13 @@
     "$id": "https://schema.beyondallreason.dev/tachyon/definitions/clanBaseData.json",
     "title": "ClanBaseData",
     "allOf": [
-        { "$ref": "../definitions/clanId.json" },
+        {
+            "type": "object",
+            "properties": {
+                "clanId": { "$ref": "../definitions/clanId.json" }
+            },
+            "required": ["clanId"]
+        },
         { "$ref": "../definitions/clanUpdateableBaseData.json" }
     ]
 }

--- a/src/schema/definitions/clan.ts
+++ b/src/schema/definitions/clan.ts
@@ -2,7 +2,9 @@ import Type from "typebox";
 
 export const clan = Type.Intersect(
     [
-        Type.Ref("clanId"),
+        Type.Object({
+            clanId: Type.Ref("clanId"),
+        }),
         Type.Ref("clanUpdateableData"),
         Type.Object({
             members: Type.Array(Type.Ref("clanMember")),

--- a/src/schema/definitions/clanBaseData.ts
+++ b/src/schema/definitions/clanBaseData.ts
@@ -1,6 +1,11 @@
 import Type from "typebox";
 
 export const clanBaseData = Type.Intersect(
-    [Type.Ref("clanId"), Type.Ref("clanUpdateableBaseData")],
+    [
+        Type.Object({
+            clanId: Type.Ref("clanId"),
+        }),
+        Type.Ref("clanUpdateableBaseData"),
+    ],
     { $id: "clanBaseData" }
 );


### PR DESCRIPTION
In clan.ts and clanBaseData.ts the Type.Intersect used directly Type.Ref("clanId") without label. Therefore it was not useable in the new client.