### PR TITLE
unboss request

### DIFF
--- a/docs/schema/lobby.md
+++ b/docs/schema/lobby.md
@@ -148,6 +148,7 @@ In practice, this event should rarely be seen.
 - [spectate](#spectate)
 - [startBattle](#startbattle)
 - [subscribeList](#subscribelist)
+- [unboss](#unboss)
 - [unsubscribeList](#unsubscribelist)
 - [update](#update)
 - [updateBot](#updatebot)
@@ -2941,6 +2942,153 @@ export interface LobbySubscribeListOkResponse {
 }
 ```
 Possible Failed Reasons: `internal_error`, `unauthorized`, `invalid_request`, `command_unimplemented`
+
+---
+
+## Unboss
+
+Unboss the given user
+
+- Endpoint Type: **Request** -> **Response**
+- Source: **User**
+- Target: **Server**
+- Required Scopes: `tachyon.lobby`
+
+### Request
+
+<details>
+<summary>JSONSchema</summary>
+
+```json
+{
+    "title": "LobbyUnbossRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "lobby/unboss" },
+        "data": {
+            "title": "LobbyUnbossRequestData",
+            "description": "if userId isn't provided, defaults to the current user",
+            "type": "object",
+            "properties": { "userId": { "$ref": "#/definitions/userId" } }
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}
+
+```
+</details>
+
+<details>
+<summary>Example</summary>
+
+```json
+{
+    "type": "request",
+    "messageId": "in nostrud pariatur",
+    "commandId": "lobby/unboss",
+    "data": {
+        "userId": "351"
+    }
+}
+```
+</details>
+
+#### TypeScript Definition
+```ts
+export type UserId = string;
+
+export interface LobbyUnbossRequest {
+    type: "request";
+    messageId: string;
+    commandId: "lobby/unboss";
+    data: LobbyUnbossRequestData;
+}
+export interface LobbyUnbossRequestData {
+    userId?: UserId;
+}
+```
+### Response
+
+<details>
+<summary>JSONSchema</summary>
+
+```json
+{
+    "title": "LobbyUnbossResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "LobbyUnbossOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "lobby/unboss" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "LobbyUnbossFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "lobby/unboss" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "not_a_boss",
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}
+
+```
+</details>
+
+<details>
+<summary>Example</summary>
+
+```json
+{
+    "type": "response",
+    "messageId": "aute adipisicing Ut aliqua laboris",
+    "commandId": "lobby/unboss",
+    "status": "success"
+}
+```
+</details>
+
+#### TypeScript Definition
+```ts
+export interface LobbyUnbossOkResponse {
+    type: "response";
+    messageId: string;
+    commandId: "lobby/unboss";
+    status: "success";
+}
+```
+Possible Failed Reasons: `not_a_boss`, `internal_error`, `unauthorized`, `invalid_request`, `command_unimplemented`
 
 ---
 

--- a/schema/compiled.json
+++ b/schema/compiled.json
@@ -4429,6 +4429,77 @@
             ]
         },
         {
+            "title": "LobbyUnbossRequest",
+            "tachyon": {
+                "source": "user",
+                "target": "server",
+                "scopes": ["tachyon.lobby"]
+            },
+            "type": "object",
+            "properties": {
+                "type": { "const": "request" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "lobby/unboss" },
+                "data": {
+                    "title": "LobbyUnbossRequestData",
+                    "description": "if userId isn't provided, defaults to the current user",
+                    "type": "object",
+                    "properties": {
+                        "userId": { "$ref": "#/definitions/userId" }
+                    }
+                }
+            },
+            "required": ["type", "messageId", "commandId", "data"]
+        },
+        {
+            "title": "LobbyUnbossResponse",
+            "tachyon": {
+                "source": "server",
+                "target": "user",
+                "scopes": ["tachyon.lobby"]
+            },
+            "anyOf": [
+                {
+                    "title": "LobbyUnbossOkResponse",
+                    "type": "object",
+                    "properties": {
+                        "type": { "const": "response" },
+                        "messageId": { "type": "string" },
+                        "commandId": { "const": "lobby/unboss" },
+                        "status": { "const": "success" }
+                    },
+                    "required": ["type", "messageId", "commandId", "status"]
+                },
+                {
+                    "title": "LobbyUnbossFailResponse",
+                    "type": "object",
+                    "properties": {
+                        "type": { "const": "response" },
+                        "messageId": { "type": "string" },
+                        "commandId": { "const": "lobby/unboss" },
+                        "status": { "const": "failed" },
+                        "reason": {
+                            "enum": [
+                                "not_a_boss",
+                                "internal_error",
+                                "unauthorized",
+                                "invalid_request",
+                                "command_unimplemented"
+                            ]
+                        },
+                        "details": { "type": "string" }
+                    },
+                    "required": [
+                        "type",
+                        "messageId",
+                        "commandId",
+                        "status",
+                        "reason"
+                    ]
+                }
+            ]
+        },
+        {
             "title": "LobbyUnsubscribeListRequest",
             "tachyon": {
                 "source": "user",

--- a/schema/lobby/unboss/request.json
+++ b/schema/lobby/unboss/request.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/unboss/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "LobbyUnbossRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "lobby/unboss" },
+        "data": {
+            "title": "LobbyUnbossRequestData",
+            "description": "if userId isn't provided, defaults to the current user",
+            "type": "object",
+            "properties": {
+                "userId": { "$ref": "../../definitions/userId.json" }
+            }
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/schema/lobby/unboss/response.json
+++ b/schema/lobby/unboss/response.json
@@ -1,0 +1,44 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/unboss/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "LobbyUnbossResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "LobbyUnbossOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "lobby/unboss" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "LobbyUnbossFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "lobby/unboss" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "not_a_boss",
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/src/schema/lobby/unboss.ts
+++ b/src/schema/lobby/unboss.ts
@@ -1,0 +1,18 @@
+import Type from "typebox";
+
+import { defineEndpoint } from "@/generator-helpers.js";
+
+export default defineEndpoint({
+    source: "user",
+    target: "server",
+    description: "Unboss the given user",
+    request: {
+        data: Type.Object(
+            {
+                userId: Type.Optional(Type.Ref("userId")),
+            },
+            { description: "if userId isn't provided, defaults to the current user" }
+        ),
+    },
+    response: [{ status: "failed", reason: "not_a_boss" }, { status: "success" }],
+});


### PR DESCRIPTION
Forgot this feature when adding bosses.
Keep the semantics of who can unboss who under which circumstance implementation specific. Passing a user id to the request is meant to support actions from moderators/admin in the future. Or perhaps if we want to trigger a vote.