### PR TITLE
Vote action when appointing a boss

### DIFF
--- a/docs/schema/lobby.md
+++ b/docs/schema/lobby.md
@@ -981,6 +981,10 @@ export type VoteActions =
     | {
           type: "changeMap";
           newMapName: string;
+      }
+    | {
+          type: "appointBoss";
+          bossId: UserId;
       };
 export type VoteOutcomes = "passed" | "failed" | "cancelled" | "timeout";
 
@@ -1434,6 +1438,10 @@ export type VoteActions =
     | {
           type: "changeMap";
           newMapName: string;
+      }
+    | {
+          type: "appointBoss";
+          bossId: UserId;
       };
 export type VoteOutcomes = "passed" | "failed" | "cancelled" | "timeout";
 
@@ -4309,8 +4317,7 @@ Sent by the server whenever something in the lobby changes. Uses json patch (RFC
         "voteHistory": {
             "td10uJ/?|": {
                 "vote": {
-                    "type": "changeMap",
-                    "newMapName": "aliquip sunt nisi proident ex"
+                    "type": "appointBoss"
                 },
                 "outcome": "failed",
                 "finishedAt": 1705432698000000
@@ -4333,6 +4340,10 @@ export type VoteActions =
     | {
           type: "changeMap";
           newMapName: string;
+      }
+    | {
+          type: "appointBoss";
+          bossId: UserId;
       };
 export type VoteOutcomes = "passed" | "failed" | "cancelled" | "timeout";
 

--- a/schema/compiled.json
+++ b/schema/compiled.json
@@ -696,6 +696,14 @@
                         "newMapName": { "type": "string" }
                     },
                     "required": ["type", "newMapName"]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "type": { "const": "appointBoss" },
+                        "bossId": { "$ref": "#/definitions/userId" }
+                    },
+                    "required": ["type", "bossId"]
                 }
             ]
         },

--- a/schema/definitions/voteActions.json
+++ b/schema/definitions/voteActions.json
@@ -14,6 +14,14 @@
                 "newMapName": { "type": "string" }
             },
             "required": ["type", "newMapName"]
+        },
+        {
+            "type": "object",
+            "properties": {
+                "type": { "const": "appointBoss" },
+                "bossId": { "$ref": "../definitions/userId.json" }
+            },
+            "required": ["type", "bossId"]
         }
     ]
 }

--- a/src/schema/definitions/voteActions.ts
+++ b/src/schema/definitions/voteActions.ts
@@ -4,6 +4,7 @@ export const voteActions = Type.Union(
     [
         Type.Object({ type: Type.Literal("start") }),
         Type.Object({ type: Type.Literal("changeMap"), newMapName: Type.String() }),
+        Type.Object({ type: Type.Literal("appointBoss"), bossId: Type.Ref("userId") }),
     ],
     { $id: "voteActions" }
 );


### PR DESCRIPTION
When a lobby allows bosses, but there is no boss, the first client to appoint a boss will trigger a vote amongst the players.