### PR TITLE
Kick (and ban) request players from lobby

### DIFF
--- a/docs/schema/lobby.md
+++ b/docs/schema/lobby.md
@@ -140,6 +140,7 @@ In practice, this event should rarely be seen.
 - [joinAllyTeam](#joinallyteam)
 - [joinBattle](#joinbattle)
 - [joinQueue](#joinqueue)
+- [kickban](#kickban)
 - [leave](#leave)
 - [left](#left)
 - [listReset](#listreset)
@@ -985,6 +986,11 @@ export type VoteActions =
     | {
           type: "appointBoss";
           bossId: UserId;
+      }
+    | {
+          type: "kickban";
+          userId: UserId;
+          banUntil?: UnixTime;
       };
 export type VoteOutcomes = "passed" | "failed" | "cancelled" | "timeout";
 
@@ -1193,6 +1199,7 @@ export interface LobbyJoinRequestData {
                 "reason": {
                     "enum": [
                         "lobby_full",
+                        "banned",
                         "internal_error",
                         "unauthorized",
                         "invalid_request",
@@ -1442,6 +1449,11 @@ export type VoteActions =
     | {
           type: "appointBoss";
           bossId: UserId;
+      }
+    | {
+          type: "kickban";
+          userId: UserId;
+          banUntil?: UnixTime;
       };
 export type VoteOutcomes = "passed" | "failed" | "cancelled" | "timeout";
 
@@ -1539,7 +1551,7 @@ export interface StartBox {
     right: number;
 }
 ```
-Possible Failed Reasons: `lobby_full`, `internal_error`, `unauthorized`, `invalid_request`, `command_unimplemented`
+Possible Failed Reasons: `lobby_full`, `banned`, `internal_error`, `unauthorized`, `invalid_request`, `command_unimplemented`
 
 ---
 
@@ -1955,6 +1967,160 @@ Possible Failed Reasons: `not_in_lobby`, `internal_error`, `unauthorized`, `inva
 
 ---
 
+## Kickban
+
+Ban a user from a lobby (and kick them out)
+
+- Endpoint Type: **Request** -> **Response**
+- Source: **User**
+- Target: **Server**
+- Required Scopes: `tachyon.lobby`
+
+### Request
+
+<details>
+<summary>JSONSchema</summary>
+
+```json
+{
+    "title": "LobbyKickbanRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "lobby/kickban" },
+        "data": {
+            "title": "LobbyKickbanRequestData",
+            "type": "object",
+            "properties": {
+                "userId": { "$ref": "#/definitions/userId" },
+                "banUntil": {
+                    "$ref": "#/definitions/unixTime",
+                    "description": "omit this field (or set it in the past) to merely kick the player"
+                }
+            },
+            "required": ["userId"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}
+
+```
+</details>
+
+<details>
+<summary>Example</summary>
+
+```json
+{
+    "type": "request",
+    "messageId": "non laborum officia dolore",
+    "commandId": "lobby/kickban",
+    "data": {
+        "userId": "351",
+        "banUntil": 1705432698000000
+    }
+}
+```
+</details>
+
+#### TypeScript Definition
+```ts
+export type UserId = string;
+
+export interface LobbyKickbanRequest {
+    type: "request";
+    messageId: string;
+    commandId: "lobby/kickban";
+    data: LobbyKickbanRequestData;
+}
+export interface LobbyKickbanRequestData {
+    userId: UserId;
+    banUntil?: number;
+}
+```
+### Response
+
+<details>
+<summary>JSONSchema</summary>
+
+```json
+{
+    "title": "LobbyKickbanResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "LobbyKickbanOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "lobby/kickban" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "LobbyKickbanFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "lobby/kickban" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}
+
+```
+</details>
+
+<details>
+<summary>Example</summary>
+
+```json
+{
+    "type": "response",
+    "messageId": "eiusmod tempor nostrud est consequat",
+    "commandId": "lobby/kickban",
+    "status": "success"
+}
+```
+</details>
+
+#### TypeScript Definition
+```ts
+export interface LobbyKickbanOkResponse {
+    type: "response";
+    messageId: string;
+    commandId: "lobby/kickban";
+    status: "success";
+}
+```
+Possible Failed Reasons: `internal_error`, `unauthorized`, `invalid_request`, `command_unimplemented`
+
+---
+
 ## Leave
 
 Leave the lobby, also unsubscribe from any update
@@ -2117,8 +2283,12 @@ Sent by the server when the player is removed from the lobby. Can be kicked/ban 
             "title": "LobbyLeftEventData",
             "type": "object",
             "properties": {
-                "id": { "type": "string" },
-                "reason": { "type": "string" }
+                "id": { "description": "lobby id", "type": "string" },
+                "reason": { "type": "string" },
+                "bannedUntil": {
+                    "$ref": "#/definitions/unixTime",
+                    "description": "if this field is set, it means the client has been banned from this lobby until that timestamp."
+                }
             },
             "required": ["id", "reason"]
         }
@@ -2138,8 +2308,8 @@ Sent by the server when the player is removed from the lobby. Can be kicked/ban 
     "messageId": "est",
     "commandId": "lobby/left",
     "data": {
-        "id": "et pariatur proident",
-        "reason": "voluptate quis consectetur"
+        "id": "pariatur nulla id",
+        "reason": "irure sunt Lorem"
     }
 }
 ```
@@ -2156,6 +2326,7 @@ export interface LobbyLeftEvent {
 export interface LobbyLeftEventData {
     id: string;
     reason: string;
+    bannedUntil?: number;
 }
 ```
 ---
@@ -4317,9 +4488,9 @@ Sent by the server whenever something in the lobby changes. Uses json patch (RFC
         "voteHistory": {
             "td10uJ/?|": {
                 "vote": {
-                    "type": "appointBoss"
+                    "type": "kickban"
                 },
-                "outcome": "failed",
+                "outcome": "timeout",
                 "finishedAt": 1705432698000000
             },
             "_LiA[]:": null
@@ -4344,6 +4515,11 @@ export type VoteActions =
     | {
           type: "appointBoss";
           bossId: UserId;
+      }
+    | {
+          type: "kickban";
+          userId: UserId;
+          banUntil?: UnixTime;
       };
 export type VoteOutcomes = "passed" | "failed" | "cancelled" | "timeout";
 

--- a/schema/compiled.json
+++ b/schema/compiled.json
@@ -704,6 +704,15 @@
                         "bossId": { "$ref": "#/definitions/userId" }
                     },
                     "required": ["type", "bossId"]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "type": { "const": "kickban" },
+                        "userId": { "$ref": "#/definitions/userId" },
+                        "banUntil": { "$ref": "#/definitions/unixTime" }
+                    },
+                    "required": ["type", "userId"]
                 }
             ]
         },
@@ -3759,6 +3768,7 @@
                         "reason": {
                             "enum": [
                                 "lobby_full",
+                                "banned",
                                 "internal_error",
                                 "unauthorized",
                                 "invalid_request",
@@ -3976,6 +3986,80 @@
             ]
         },
         {
+            "title": "LobbyKickbanRequest",
+            "tachyon": {
+                "source": "user",
+                "target": "server",
+                "scopes": ["tachyon.lobby"]
+            },
+            "type": "object",
+            "properties": {
+                "type": { "const": "request" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "lobby/kickban" },
+                "data": {
+                    "title": "LobbyKickbanRequestData",
+                    "type": "object",
+                    "properties": {
+                        "userId": { "$ref": "#/definitions/userId" },
+                        "banUntil": {
+                            "$ref": "#/definitions/unixTime",
+                            "description": "omit this field (or set it in the past) to merely kick the player"
+                        }
+                    },
+                    "required": ["userId"]
+                }
+            },
+            "required": ["type", "messageId", "commandId", "data"]
+        },
+        {
+            "title": "LobbyKickbanResponse",
+            "tachyon": {
+                "source": "server",
+                "target": "user",
+                "scopes": ["tachyon.lobby"]
+            },
+            "anyOf": [
+                {
+                    "title": "LobbyKickbanOkResponse",
+                    "type": "object",
+                    "properties": {
+                        "type": { "const": "response" },
+                        "messageId": { "type": "string" },
+                        "commandId": { "const": "lobby/kickban" },
+                        "status": { "const": "success" }
+                    },
+                    "required": ["type", "messageId", "commandId", "status"]
+                },
+                {
+                    "title": "LobbyKickbanFailResponse",
+                    "type": "object",
+                    "properties": {
+                        "type": { "const": "response" },
+                        "messageId": { "type": "string" },
+                        "commandId": { "const": "lobby/kickban" },
+                        "status": { "const": "failed" },
+                        "reason": {
+                            "enum": [
+                                "internal_error",
+                                "unauthorized",
+                                "invalid_request",
+                                "command_unimplemented"
+                            ]
+                        },
+                        "details": { "type": "string" }
+                    },
+                    "required": [
+                        "type",
+                        "messageId",
+                        "commandId",
+                        "status",
+                        "reason"
+                    ]
+                }
+            ]
+        },
+        {
             "title": "LobbyLeaveRequest",
             "tachyon": {
                 "source": "user",
@@ -4053,8 +4137,12 @@
                     "title": "LobbyLeftEventData",
                     "type": "object",
                     "properties": {
-                        "id": { "type": "string" },
-                        "reason": { "type": "string" }
+                        "id": { "description": "lobby id", "type": "string" },
+                        "reason": { "type": "string" },
+                        "bannedUntil": {
+                            "$ref": "#/definitions/unixTime",
+                            "description": "if this field is set, it means the client has been banned from this lobby until that timestamp."
+                        }
                     },
                     "required": ["id", "reason"]
                 }

--- a/schema/definitions/voteActions.json
+++ b/schema/definitions/voteActions.json
@@ -22,6 +22,15 @@
                 "bossId": { "$ref": "../definitions/userId.json" }
             },
             "required": ["type", "bossId"]
+        },
+        {
+            "type": "object",
+            "properties": {
+                "type": { "const": "kickban" },
+                "userId": { "$ref": "../definitions/userId.json" },
+                "banUntil": { "$ref": "../definitions/unixTime.json" }
+            },
+            "required": ["type", "userId"]
         }
     ]
 }

--- a/schema/lobby/kickban/request.json
+++ b/schema/lobby/kickban/request.json
@@ -1,0 +1,29 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/kickban/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "LobbyKickbanRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "lobby/kickban" },
+        "data": {
+            "title": "LobbyKickbanRequestData",
+            "type": "object",
+            "properties": {
+                "userId": { "$ref": "../../definitions/userId.json" },
+                "banUntil": {
+                    "$ref": "../../definitions/unixTime.json",
+                    "description": "omit this field (or set it in the past) to merely kick the player"
+                }
+            },
+            "required": ["userId"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/schema/lobby/kickban/response.json
+++ b/schema/lobby/kickban/response.json
@@ -1,7 +1,7 @@
 {
-    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/join/response.json",
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/kickban/response.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "LobbyJoinResponse",
+    "title": "LobbyKickbanResponse",
     "tachyon": {
         "source": "server",
         "target": "user",
@@ -9,32 +9,26 @@
     },
     "anyOf": [
         {
-            "title": "LobbyJoinOkResponse",
+            "title": "LobbyKickbanOkResponse",
             "type": "object",
             "properties": {
                 "type": { "const": "response" },
                 "messageId": { "type": "string" },
-                "commandId": { "const": "lobby/join" },
-                "status": { "const": "success" },
-                "data": {
-                    "$ref": "../../definitions/lobbyDetails.json",
-                    "title": "LobbyJoinOkResponseData"
-                }
+                "commandId": { "const": "lobby/kickban" },
+                "status": { "const": "success" }
             },
-            "required": ["type", "messageId", "commandId", "status", "data"]
+            "required": ["type", "messageId", "commandId", "status"]
         },
         {
-            "title": "LobbyJoinFailResponse",
+            "title": "LobbyKickbanFailResponse",
             "type": "object",
             "properties": {
                 "type": { "const": "response" },
                 "messageId": { "type": "string" },
-                "commandId": { "const": "lobby/join" },
+                "commandId": { "const": "lobby/kickban" },
                 "status": { "const": "failed" },
                 "reason": {
                     "enum": [
-                        "lobby_full",
-                        "banned",
                         "internal_error",
                         "unauthorized",
                         "invalid_request",

--- a/schema/lobby/left/event.json
+++ b/schema/lobby/left/event.json
@@ -16,8 +16,12 @@
             "title": "LobbyLeftEventData",
             "type": "object",
             "properties": {
-                "id": { "type": "string" },
-                "reason": { "type": "string" }
+                "id": { "description": "lobby id", "type": "string" },
+                "reason": { "type": "string" },
+                "bannedUntil": {
+                    "$ref": "../../definitions/unixTime.json",
+                    "description": "if this field is set, it means the client has been banned from this lobby until that timestamp."
+                }
             },
             "required": ["id", "reason"]
         }

--- a/src/schema/definitions/voteActions.ts
+++ b/src/schema/definitions/voteActions.ts
@@ -5,6 +5,11 @@ export const voteActions = Type.Union(
         Type.Object({ type: Type.Literal("start") }),
         Type.Object({ type: Type.Literal("changeMap"), newMapName: Type.String() }),
         Type.Object({ type: Type.Literal("appointBoss"), bossId: Type.Ref("userId") }),
+        Type.Object({
+            type: Type.Literal("kickban"),
+            userId: Type.Ref("userId"),
+            banUntil: Type.Optional(Type.Ref("unixTime")),
+        }),
     ],
     { $id: "voteActions" }
 );

--- a/src/schema/lobby/join.ts
+++ b/src/schema/lobby/join.ts
@@ -14,6 +14,7 @@ export default defineEndpoint({
     },
     response: [
         { status: "failed", reason: "lobby_full" },
+        { status: "failed", reason: "banned" },
         {
             status: "success",
             data: Type.Ref("lobbyDetails"),

--- a/src/schema/lobby/kickban.ts
+++ b/src/schema/lobby/kickban.ts
@@ -1,0 +1,21 @@
+import Type from "typebox";
+
+import { defineEndpoint } from "@/generator-helpers.js";
+
+export default defineEndpoint({
+    source: "user",
+    target: "server",
+    description: "Ban a user from a lobby (and kick them out)",
+    request: {
+        data: Type.Object({
+            userId: Type.Ref("userId"),
+            banUntil: Type.Optional(
+                Type.Ref("unixTime", {
+                    description:
+                        "omit this field (or set it in the past) to merely kick the player",
+                })
+            ),
+        }),
+    },
+    response: [{ status: "success" }],
+});

--- a/src/schema/lobby/left.ts
+++ b/src/schema/lobby/left.ts
@@ -9,8 +9,14 @@ export default defineEndpoint({
         "Sent by the server when the player is removed from the lobby. Can be kicked/ban or the lobby crashed",
     event: {
         data: Type.Object({
-            id: Type.String(),
+            id: Type.String({ description: "lobby id" }),
             reason: Type.String(),
+            bannedUntil: Type.Optional(
+                Type.Ref("unixTime", {
+                    description:
+                        "if this field is set, it means the client has been banned from this lobby until that timestamp.",
+                })
+            ),
         }),
     },
 });


### PR DESCRIPTION
The overview:

* same request to kick and ban, the difference is marked with an optional field `banUntil`
* lobbies have a list of banned player. Not sure about that, that may be useful, but also could be dropped.
* one of the limitation of our schemas is that we can't put additional data in the error results. So when one joins a lobby but is banned, we can only say "you are banned", but not until when.