### PR TITLE
Fix privateBattle Ids and improve typing in privateUser Ids

### DIFF
--- a/docs/schema/battle.md
+++ b/docs/schema/battle.md
@@ -209,18 +209,22 @@ When a user client receives this response it should launch the game (spring.exe)
     "messageId": "qui incididunt",
     "commandId": "battle/start",
     "data": {
-        "username": "enim id",
-        "password": "dolore adipisicing in",
-        "ip": "75bfc493-2b9d-495d-a453-06722fdca2ea",
-        "port": -21385347.843170166,
+        "battleId": "75bfc493-2b9d-495d-a453-06722fdca2ea",
+        "username": "officia enim aliquip aute",
+        "password": "aliqua adipisicing dolore",
+        "ips": [
+            "129.211.80.128",
+            "983a:2b5c:c1a8:3205:e6bd:3dbe:9bdf:017f"
+        ],
+        "port": 46973,
         "engine": {
-            "version": "velit eu"
+            "version": "deserunt"
         },
         "game": {
-            "springName": "id minim aute sed amet"
+            "springName": "ipsum proident sit sunt"
         },
         "map": {
-            "springName": "aliquip adipisicing elit"
+            "springName": "voluptate"
         }
     }
 }
@@ -238,9 +242,10 @@ export interface BattleStartRequest {
     data: BattleStartRequestData;
 }
 export interface BattleStartRequestData {
+    battleId: BattleId;
     username: string;
     password: string;
-    ip: BattleId;
+    ips: string[];
     port: number;
     engine: {
         version: string;

--- a/docs/schema/user.md
+++ b/docs/schema/user.md
@@ -467,14 +467,12 @@ Sent by the server to inform the client of its own user state. This event should
                 ]
             },
             "invitedToParties": [],
-            "friendIds": [
-                "labore",
-                "dolore reprehenderit velit minim sunt",
-                "occaecat veniam",
-                "labore",
-                "Excepteur occaecat do esse mollit"
-            ],
+            "friendIds": [],
             "outgoingFriendRequest": [
+                {
+                    "to": {},
+                    "sentAt": {}
+                },
                 {
                     "to": {},
                     "sentAt": {}
@@ -500,35 +498,42 @@ Sent by the server to inform the client of its own user state. This event should
                 {
                     "from": {},
                     "sentAt": {}
+                },
+                {
+                    "from": {},
+                    "sentAt": {}
+                },
+                {
+                    "from": {},
+                    "sentAt": {}
+                },
+                {
+                    "from": {},
+                    "sentAt": {}
                 }
             ],
-            "ignoreIds": [
-                "veniam elit",
-                "velit pariatur cillum officia qui",
-                "in amet occaecat nostrud",
-                "fugiat"
-            ],
+            "ignoreIds": [],
             "currentBattle": {
                 "battleId": "75bfc493-2b9d-495d-a453-06722fdca2ea",
-                "username": "reprehenderit Excepteur Lorem",
-                "password": "Excepteur adipisicing commodo ea eu",
+                "username": "amet nulla",
+                "password": "quis eiusmod in ut veniam",
                 "ips": [
-                    "d977:479d:a6ee:e542:6468:926b:d42f:d0d7",
-                    "d54d:1c1c:a376:2270:3184:3de0:cdd0:8265",
-                    "201.52.144.46"
+                    "38c9:73c9:bfd1:63bc:f84a:6005:cd0c:8549",
+                    "15.28.128.124",
+                    "44.32.74.70"
                 ],
-                "port": 6121,
+                "port": 19974,
                 "engine": {
-                    "version": "Duis enim do veniam dolore"
+                    "version": "deserunt esse"
                 },
                 "game": {
-                    "springName": "pariatur"
+                    "springName": "labore in"
                 },
                 "map": {
-                    "springName": "occaecat eu in"
+                    "springName": "quis in veniam sed"
                 }
             },
-            "currentLobby": "tempor aliqua qui Ut",
+            "currentLobby": null,
             "clanInvites": [
                 "12345",
                 "12345",
@@ -536,29 +541,7 @@ Sent by the server to inform the client of its own user state. This event should
                 "12345"
             ],
             "matchmaking": {
-                "state": "queuing",
-                "queues": [
-                    {
-                        "id": "qui nostrud fugiat in",
-                        "version": "ut mollit"
-                    },
-                    {
-                        "id": "et cillum minim est commodo",
-                        "version": "tempor dolore in"
-                    },
-                    {
-                        "id": "elit sit velit Duis incididunt",
-                        "version": "Lorem"
-                    },
-                    {
-                        "id": "enim exercitation ipsum labore",
-                        "version": "dolor minim Duis consectetur nostrud"
-                    },
-                    {
-                        "id": "adipisicing",
-                        "version": "dolore sed laborum aliqua"
-                    }
-                ]
+                "state": "no_matchmaking"
             }
         }
     }
@@ -571,7 +554,7 @@ Sent by the server to inform the client of its own user state. This event should
 export type PrivateUser = User & {
     party: PartyState | null;
     invitedToParties: PartyState[];
-    friendIds: string[];
+    friendIds: UserId[];
     outgoingFriendRequest: {
         to: UserId;
         sentAt: UnixTime;
@@ -580,9 +563,9 @@ export type PrivateUser = User & {
         from: UserId;
         sentAt: UnixTime;
     }[];
-    ignoreIds: string[];
+    ignoreIds: UserId[];
     currentBattle?: PrivateBattle;
-    currentLobby: string | null;
+    currentLobby: LobbyId | null;
     clanInvites: ClanId[];
     matchmaking:
         | {
@@ -620,6 +603,7 @@ export type ClanId = string;
 export type PartyId = string;
 export type UnixTime = number;
 export type BattleId = string;
+export type LobbyId = string;
 
 export interface UserSelfEvent {
     type: "event";

--- a/docs/schema/user.md
+++ b/docs/schema/user.md
@@ -509,22 +509,28 @@ Sent by the server to inform the client of its own user state. This event should
                 "fugiat"
             ],
             "currentBattle": {
-                "username": "tempor",
-                "password": "pariatur ad exercitation nulla",
-                "ip": "75bfc493-2b9d-495d-a453-06722fdca2ea",
-                "port": 18174040.3175354,
+                "battleId": "75bfc493-2b9d-495d-a453-06722fdca2ea",
+                "username": "reprehenderit Excepteur Lorem",
+                "password": "Excepteur adipisicing commodo ea eu",
+                "ips": [
+                    "d977:479d:a6ee:e542:6468:926b:d42f:d0d7",
+                    "d54d:1c1c:a376:2270:3184:3de0:cdd0:8265",
+                    "201.52.144.46"
+                ],
+                "port": 6121,
                 "engine": {
-                    "version": "officia exercitation nulla ex labore"
+                    "version": "Duis enim do veniam dolore"
                 },
                 "game": {
-                    "springName": "elit sunt"
+                    "springName": "pariatur"
                 },
                 "map": {
-                    "springName": "in labore est"
+                    "springName": "occaecat eu in"
                 }
             },
-            "currentLobby": "do aute esse",
+            "currentLobby": "tempor aliqua qui Ut",
             "clanInvites": [
+                "12345",
                 "12345",
                 "12345",
                 "12345"
@@ -533,24 +539,24 @@ Sent by the server to inform the client of its own user state. This event should
                 "state": "queuing",
                 "queues": [
                     {
-                        "id": "est tempor cillum culpa",
-                        "version": "reprehenderit"
+                        "id": "qui nostrud fugiat in",
+                        "version": "ut mollit"
                     },
                     {
-                        "id": "amet ut aute reprehenderit veniam",
-                        "version": "culpa nisi reprehenderit laboris deserunt"
+                        "id": "et cillum minim est commodo",
+                        "version": "tempor dolore in"
                     },
                     {
-                        "id": "magna aliqua nisi",
-                        "version": "nisi"
+                        "id": "elit sit velit Duis incididunt",
+                        "version": "Lorem"
                     },
                     {
-                        "id": "pariatur consectetur officia dolore do",
-                        "version": "in laborum amet"
+                        "id": "enim exercitation ipsum labore",
+                        "version": "dolor minim Duis consectetur nostrud"
                     },
                     {
-                        "id": "est non exercitation",
-                        "version": "sint et"
+                        "id": "adipisicing",
+                        "version": "dolore sed laborum aliqua"
                     }
                 ]
             }
@@ -658,9 +664,10 @@ export interface PartyState {
     }[];
 }
 export interface PrivateBattle {
+    battleId: BattleId;
     username: string;
     password: string;
-    ip: BattleId;
+    ips: string[];
     port: number;
     engine: {
         version: string;

--- a/schema/compiled.json
+++ b/schema/compiled.json
@@ -469,10 +469,23 @@
             "description": "Battle informations including secrets to pass to spring for joining the game server. Don't expose secrets to other players.",
             "type": "object",
             "properties": {
+                "battleId": { "$ref": "#/definitions/battleId" },
                 "username": { "type": "string" },
                 "password": { "type": "string" },
-                "ip": { "$ref": "#/definitions/battleId" },
-                "port": { "type": "number" },
+                "ips": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            { "type": "string", "format": "ipv4" },
+                            { "type": "string", "format": "ipv6" }
+                        ]
+                    }
+                },
+                "port": {
+                    "type": "integer",
+                    "minimum": 1024,
+                    "maximum": 65535
+                },
                 "engine": {
                     "type": "object",
                     "properties": { "version": { "type": "string" } },
@@ -490,9 +503,10 @@
                 }
             },
             "required": [
+                "battleId",
                 "username",
                 "password",
-                "ip",
+                "ips",
                 "port",
                 "engine",
                 "game",

--- a/schema/compiled.json
+++ b/schema/compiled.json
@@ -531,7 +531,7 @@
                         },
                         "friendIds": {
                             "type": "array",
-                            "items": { "type": "string" }
+                            "items": { "$ref": "#/definitions/userId" }
                         },
                         "outgoingFriendRequest": {
                             "type": "array",
@@ -561,13 +561,16 @@
                         },
                         "ignoreIds": {
                             "type": "array",
-                            "items": { "type": "string" }
+                            "items": { "$ref": "#/definitions/userId" }
                         },
                         "currentBattle": {
                             "$ref": "#/definitions/privateBattle"
                         },
                         "currentLobby": {
-                            "anyOf": [{ "type": "string" }, { "type": "null" }]
+                            "anyOf": [
+                                { "$ref": "#/definitions/lobbyId" },
+                                { "type": "null" }
+                            ]
                         },
                         "clanInvites": {
                             "type": "array",

--- a/schema/definitions/privateBattle.json
+++ b/schema/definitions/privateBattle.json
@@ -4,10 +4,19 @@
     "description": "Battle informations including secrets to pass to spring for joining the game server. Don't expose secrets to other players.",
     "type": "object",
     "properties": {
+        "battleId": { "$ref": "../definitions/battleId.json" },
         "username": { "type": "string" },
         "password": { "type": "string" },
-        "ip": { "$ref": "../definitions/battleId.json" },
-        "port": { "type": "number" },
+        "ips": {
+            "type": "array",
+            "items": {
+                "anyOf": [
+                    { "type": "string", "format": "ipv4" },
+                    { "type": "string", "format": "ipv6" }
+                ]
+            }
+        },
+        "port": { "type": "integer", "minimum": 1024, "maximum": 65535 },
         "engine": {
             "type": "object",
             "properties": { "version": { "type": "string" } },
@@ -24,5 +33,14 @@
             "required": ["springName"]
         }
     },
-    "required": ["username", "password", "ip", "port", "engine", "game", "map"]
+    "required": [
+        "battleId",
+        "username",
+        "password",
+        "ips",
+        "port",
+        "engine",
+        "game",
+        "map"
+    ]
 }

--- a/schema/definitions/privateUser.json
+++ b/schema/definitions/privateUser.json
@@ -16,7 +16,10 @@
                     "type": "array",
                     "items": { "$ref": "../definitions/partyState.json" }
                 },
-                "friendIds": { "type": "array", "items": { "type": "string" } },
+                "friendIds": {
+                    "type": "array",
+                    "items": { "$ref": "../definitions/userId.json" }
+                },
                 "outgoingFriendRequest": {
                     "type": "array",
                     "items": {
@@ -39,12 +42,18 @@
                         "required": ["from", "sentAt"]
                     }
                 },
-                "ignoreIds": { "type": "array", "items": { "type": "string" } },
+                "ignoreIds": {
+                    "type": "array",
+                    "items": { "$ref": "../definitions/userId.json" }
+                },
                 "currentBattle": {
                     "$ref": "../definitions/privateBattle.json"
                 },
                 "currentLobby": {
-                    "anyOf": [{ "type": "string" }, { "type": "null" }]
+                    "anyOf": [
+                        { "$ref": "../definitions/lobbyId.json" },
+                        { "type": "null" }
+                    ]
                 },
                 "clanInvites": {
                     "type": "array",

--- a/src/schema/definitions/privateBattle.ts
+++ b/src/schema/definitions/privateBattle.ts
@@ -2,10 +2,13 @@ import Type from "typebox";
 
 export const privateBattle = Type.Object(
     {
+        battleId: Type.Ref("battleId"),
         username: Type.String(),
         password: Type.String(),
-        ip: Type.Ref("battleId"),
-        port: Type.Number(),
+        ips: Type.Array(
+            Type.Union([Type.String({ format: "ipv4" }), Type.String({ format: "ipv6" })])
+        ),
+        port: Type.Integer({ minimum: 1024, maximum: 65535 }),
         engine: Type.Object({
             version: Type.String(),
         }),

--- a/src/schema/definitions/privateUser.ts
+++ b/src/schema/definitions/privateUser.ts
@@ -39,7 +39,7 @@ export const privateUser = Type.Intersect(
         Type.Object({
             party: Nullable(Type.Ref("partyState")),
             invitedToParties: Type.Array(Type.Ref("partyState")),
-            friendIds: Type.Array(Type.String()),
+            friendIds: Type.Array(Type.Ref("userId")),
             outgoingFriendRequest: Type.Array(
                 Type.Object({
                     to: Type.Ref("userId"),
@@ -52,9 +52,9 @@ export const privateUser = Type.Intersect(
                     sentAt: Type.Ref("unixTime"),
                 })
             ),
-            ignoreIds: Type.Array(Type.String()),
+            ignoreIds: Type.Array(Type.Ref("userId")),
             currentBattle: Type.Optional(Type.Ref("privateBattle")),
-            currentLobby: Nullable(Type.String()),
+            currentLobby: Nullable(Type.Ref("lobbyId")),
             clanInvites: Type.Array(Type.Ref("clanId")),
             matchmaking: Type.Union([noMatchmaking, queueing, foundMatch]),
         }),


### PR DESCRIPTION
- IP is not battleId, battleId is unique UUID. Here we flip the `ip` to `ips` and make port type more strict mirroring definition in autohost schema.
- Small improvement to add id types in privateUser noticed as I was checking other Id usage.